### PR TITLE
moved workflows to main dir

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      working-directory: model_catalogs
       with:
         python-version: '3.8'
     - uses: pre-commit/action@v2.0.0
+      working-directory: model_catalogs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda
+        working-directory: model_catalogs
         uses: actions/cache@v1
         env:
           # Increase this value to reset cache if ci/environment.yml has not changed
@@ -29,6 +30,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('ci/environment-py${{ matrix.python-version }}.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
+        working-directory: model_catalogs
         with:
           # mamba-version: "*" # activate this to build with mamba.
           # channels: conda-forge, defaults # These need to be specified to use mamba
@@ -39,14 +41,17 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
       - name: Set up conda environment
         shell: bash -l {0}
+        working-directory: model_catalogs
         run: |
           python -m pip install -e . --no-deps --force-reinstall
       - name: Run Tests
         shell: bash -l {0}
+        working-directory: model_catalogs
         run: |
           pytest --cov=./ --cov-report=xml
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v1
+        working-directory: model_catalogs
         with:
           file: ./coverage.xml
           flags: unittests


### PR DESCRIPTION
Apparently the .github/workflows dir has to be in the main repo directory, but I added notes to point to model_catalogs as the working directory. I will see if this works.