### PR TITLE
updating ci python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8", "3.9"]
     steps:
       - uses: actions/checkout@v2
       - name: Cache conda

--- a/model_catalogs/ci/environment-py3.9.yml
+++ b/model_catalogs/ci/environment-py3.9.yml
@@ -2,7 +2,7 @@ name: test_env_model_catalogs
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.9
   ############## These will have to be adjusted to your specific project
   - alphashape
   - cf_xarray


### PR DESCRIPTION
Now testing 3.8 and 3.9 instead of 3.7 and 3.8.