### PR TITLE
Adds fetch examples for remaining rectangular OFS models

### DIFF
--- a/model_catalogs/model_catalogs/catalogs/orig/gfs-1deg.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gfs-1deg.yaml
@@ -21,6 +21,16 @@ sources:
       overall_end_datetime: '16 days from today.'
       output_period_(hr): 3
       axis:
+        # time is for instantaneous variables which are most
+        # time2 is the time dimension for averaged variables
+        # time3 is for precipitation accumulation variables
         T: ['time', 'time2', 'time1', 'time3']
       standard_names:
         time: time
+        air_temperature: Temperature_height_above_ground
+        wind_u: u-component_of_wind_height_above_ground
+        wind_v: v-component_of_wind_height_above_ground
+        wind_gust: Wind_speed_gust_surface
+        dew_point_temperature: Dewpoint_temperature_height_above_ground
+        longitude: lon
+        latitude: lat

--- a/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
@@ -37,9 +37,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   nowcast:
     driver: opendap
@@ -76,9 +76,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast:
     driver: opendap
@@ -115,9 +115,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -146,6 +146,6 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat

--- a/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
@@ -38,8 +38,10 @@ sources:
         sea_water_temperature: temp
         time: time
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   nowcast:
     driver: opendap
@@ -77,8 +79,10 @@ sources:
         sea_water_temperature: temp
         time: time
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast:
     driver: opendap
@@ -116,8 +120,10 @@ sources:
         sea_water_temperature: temp
         time: time
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -147,5 +153,7 @@ sources:
         sea_water_temperature: temp
         time: time
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon

--- a/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
@@ -37,6 +37,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
+      cf_coordinates:
+        - longitude
+        - latitude
 
   nowcast:
     driver: opendap
@@ -73,6 +76,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast:
     driver: opendap
@@ -109,6 +115,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -137,3 +146,6 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         sea_water_temperature: temp
         time: time
+      cf_coordinates:
+        - longitude
+        - latitude

--- a/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
@@ -39,8 +39,10 @@ sources:
         longitude: lon
         latitude: lat
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   nowcast:
     driver: opendap
@@ -80,8 +82,10 @@ sources:
         longitude: lon
         latitude: lat
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast:
     driver: opendap
@@ -121,8 +125,10 @@ sources:
         longitude: lon
         latitude: lat
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -154,5 +160,7 @@ sources:
         longitude: lon
         latitude: lat
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon

--- a/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
@@ -38,9 +38,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   nowcast:
     driver: opendap
@@ -79,9 +79,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast:
     driver: opendap
@@ -120,9 +120,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -153,6 +153,6 @@ sources:
         time: time
         longitude: lon
         latitude: lat
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat

--- a/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
@@ -38,6 +38,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
+      cf_coordinates:
+        - longitude
+        - latitude
 
   nowcast:
     driver: opendap
@@ -76,6 +79,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast:
     driver: opendap
@@ -114,6 +120,9 @@ sources:
         time: time
         longitude: lon
         latitude: lat
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -144,3 +153,6 @@ sources:
         time: time
         longitude: lon
         latitude: lat
+      cf_coordinates:
+        - longitude
+        - latitude

--- a/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
@@ -37,8 +37,10 @@ sources:
         time: time
         upward_sea_water_velocity: w
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   nowcast:
     driver: opendap
@@ -77,8 +79,10 @@ sources:
         time: time
         upward_sea_water_velocity: w
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast:
     driver: opendap
@@ -115,8 +119,10 @@ sources:
         time: time
         upward_sea_water_velocity: w
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -146,5 +152,7 @@ sources:
         time: time
         upward_sea_water_velocity: w
       coords:
-        - lon
+        - time
+        - sigma
         - lat
+        - lon

--- a/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
@@ -36,9 +36,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   nowcast:
     driver: opendap
@@ -76,9 +76,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast:
     driver: opendap
@@ -114,9 +114,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -145,6 +145,6 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
-      cf_coordinates:
-        - longitude
-        - latitude
+      coords:
+        - lon
+        - lat

--- a/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
@@ -36,6 +36,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
+      cf_coordinates:
+        - longitude
+        - latitude
 
   nowcast:
     driver: opendap
@@ -73,6 +76,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast:
     driver: opendap
@@ -108,6 +114,9 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
+      cf_coordinates:
+        - longitude
+        - latitude
 
   hindcast-forecast-aggregation:
     driver: opendap
@@ -136,3 +145,6 @@ sources:
         sea_surface_height_above_mean_sea_level: zeta
         time: time
         upward_sea_water_velocity: w
+      cf_coordinates:
+        - longitude
+        - latitude

--- a/model_catalogs/model_catalogs/examples.py
+++ b/model_catalogs/model_catalogs/examples.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """A module for common components for scripting examples."""
 import time
+
 from argparse import ArgumentParser
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -14,6 +15,7 @@ import model_catalogs as mc
 
 class Timer:
     """A class to aid with measuring timing."""
+
     def __init__(self, msg=None):
         """Initializes the current time."""
         self.t0 = time.time()
@@ -25,7 +27,7 @@ class Timer:
 
     def tock(self) -> float:
         """Return elapsed time in ms."""
-        return (time.time() - self.t0) * 1000.
+        return (time.time() - self.t0) * 1000.0
 
     def __enter__(self):
         """With context."""
@@ -38,26 +40,27 @@ class Timer:
 
 
 STANDARD_NAMES = [
-    'eastward_sea_water_velocity',
-    'northward_sea_water_velocity',
-    'eastward_wind',
-    'northward_wind',
-    'sea_water_temperature',
-    'sea_water_practical_salinity',
-    'sea_floor_depth',
+    "eastward_sea_water_velocity",
+    "northward_sea_water_velocity",
+    "eastward_wind",
+    "northward_wind",
+    "sea_water_temperature",
+    "sea_water_practical_salinity",
+    "sea_floor_depth",
 ]
 
 
 @dataclass
 class FetchConfig:
     """Configuration data class for fetching."""
+
     model_name: str
     output_pth: Path
     start: pd.Timestamp
     end: pd.Timestamp
     bbox: Tuple[float, float, float, float]
     timing: str
-    standard_names: List[str] = field(default_factory=lambda : STANDARD_NAMES)
+    standard_names: List[str] = field(default_factory=lambda: STANDARD_NAMES)
 
 
 def parse_bbox(val: str) -> Tuple[float, float, float, float]:
@@ -72,31 +75,36 @@ def parse_bbox(val: str) -> Tuple[float, float, float, float]:
     -------
         tuple of 4 floats
     """
-    values = val.split(',')
+    values = val.split(",")
     if len(values) != 4:
-        raise ValueError('bbox should include four numbers: lon_min,lat_min,lon_max,lat_max')
+        raise ValueError(
+            "bbox should include four numbers: lon_min,lat_min,lon_max,lat_max"
+        )
     return tuple(float(i) for i in values)
 
 
 def fetch(fetch_config):
-    print('Setting up source catalog')
-    with Timer('\tSource catalog generated in {:.1f} ms'):
+    print("Setting up source catalog")
+    with Timer("\tSource catalog generated in {:.1f} ms"):
         source_catalog = mc.setup_source_catalog()
 
-    print(f'Generating catalog specific for {fetch_config.model_name} {fetch_config.timing}')
-    with Timer('\tSpecific catalog generated in {:.1f} ms'):
-        catalog = mc.add_url_path(source_catalog[fetch_config.model_name],
-                                  timing=fetch_config.timing,
-                                  start_date=fetch_config.start,
-                                  end_date=fetch_config.end)
-    print('Getting xarray dataset for model data')
-    with Timer('\tCreated dask-based xarray dataset in {:.1f} ms'):
+    print(
+        f"Generating catalog specific for {fetch_config.model_name} {fetch_config.timing}"
+    )
+    with Timer("\tSpecific catalog generated in {:.1f} ms"):
+        catalog = mc.add_url_path(
+            source_catalog[fetch_config.model_name],
+            timing=fetch_config.timing,
+            start_date=fetch_config.start,
+            end_date=fetch_config.end,
+        )
+    print("Getting xarray dataset for model data")
+    with Timer("\tCreated dask-based xarray dataset in {:.1f} ms"):
         ds = catalog[fetch_config.model_name].to_dask()
-    print('Subsetting data')
-    with Timer('\tSubsetted dataset in {:.1f} ms'):
+    print("Subsetting data")
+    with Timer("\tSubsetted dataset in {:.1f} ms"):
         ds_ss = (
-            ds
-            .em.filter(fetch_config.standard_names)
+            ds.em.filter(fetch_config.standard_names)
             .cf.sel(T=slice(fetch_config.start, fetch_config.end))
             .em.sub_grid(bbox=fetch_config.bbox)
         )
@@ -104,68 +112,73 @@ def fetch(fetch_config):
         #   a global attribute that originates from NETCDF3. However when xarray attempts to write
         #   this special global attribute to disk, the netCDF-C library will throw an exception. See
         #   https://github.com/pydata/xarray/issues/2822 for details.
-        if '_NCProperties' in ds_ss.attrs:
-            del ds_ss.attrs['_NCProperties']
-    print(f'Writing netCDF data to {fetch_config.output_pth}. This may take a long time...')
-    with Timer('\tWrote output to disk in {:.1f} ms'):
+        if "_NCProperties" in ds_ss.attrs:
+            del ds_ss.attrs["_NCProperties"]
+    print(
+        f"Writing netCDF data to {fetch_config.output_pth}. This may take a long time..."
+    )
+    with Timer("\tWrote output to disk in {:.1f} ms"):
         ds_ss.to_netcdf(fetch_config.output_pth)
-    print('Complete')
+    print("Complete")
 
 
-def parse_config(main,
-                 model_name,
-                 default_bbox,
-                 output_dir,
-                 default_timing='hindcast',
-                 standard_names=None,
-                 default_start=None,
-                 default_end=None) -> FetchConfig:
+def parse_config(
+    main,
+    model_name,
+    default_bbox,
+    output_dir,
+    default_timing="hindcast",
+    standard_names=None,
+    default_start=None,
+    default_end=None,
+) -> FetchConfig:
     if standard_names is None:
         standard_names = STANDARD_NAMES
     parser = ArgumentParser(description=main.__doc__)
-    parser.add_argument('-t',
-                        '--timing',
-                        choices=['hindcast', 'nowcast', 'forecast'],
-                        default=default_timing,
-                        help='Model Timing Choice.')
-    parser.add_argument('-s',
-                        '--start',
-                        type=pd.Timestamp,
-                        default=default_start,
-                        help='Request start time')
-    parser.add_argument('-e',
-                        '--end',
-                        type=pd.Timestamp,
-                        default=default_end,
-                        help='Request end time')
-    parser.add_argument('-f', '--force', action='store_true', help='Overwrite existing files')
-    parser.add_argument('--bbox',
-                        type=parse_bbox,
-                        default=default_bbox,
-                        help='Specify the bounding box')
+    parser.add_argument(
+        "-t",
+        "--timing",
+        choices=["hindcast", "nowcast", "forecast"],
+        default=default_timing,
+        help="Model Timing Choice.",
+    )
+    parser.add_argument(
+        "-s",
+        "--start",
+        type=pd.Timestamp,
+        default=default_start,
+        help="Request start time",
+    )
+    parser.add_argument(
+        "-e", "--end", type=pd.Timestamp, default=default_end, help="Request end time"
+    )
+    parser.add_argument(
+        "-f", "--force", action="store_true", help="Overwrite existing files"
+    )
+    parser.add_argument(
+        "--bbox", type=parse_bbox, default=default_bbox, help="Specify the bounding box"
+    )
     args = parser.parse_args()
 
     # Sanity check on start/end time
     if args.start is None and args.end is None:
-        start = pd.Timestamp('2022-06-20')
-        end = pd.Timestamp('2022-06-21')
+        start = pd.Timestamp("2022-06-20")
+        end = pd.Timestamp("2022-06-21")
     elif args.start is None or args.end is None:
-        raise ValueError('start time or end time not specified')
+        raise ValueError("start time or end time not specified")
     else:
         start = args.start
         end = args.end
     if start >= end:
-        raise ValueError('end time must be greater than start time')
+        raise ValueError("end time must be greater than start time")
 
-    output_filename = (
-        f'{model_name}_{args.timing}_{start:%Y%m%d}-{end:%Y%m%d}.nc'
-    )
+    output_filename = f"{model_name}_{args.timing}_{start:%Y%m%d}-{end:%Y%m%d}.nc"
     output_pth = output_dir / output_filename
     if output_pth.exists():
         if args.force:
             output_pth.unlink()
         else:
-            raise FileExistsError(f'{output_pth} already exists')
+            raise FileExistsError(f"{output_pth} already exists")
 
     return FetchConfig(
         model_name=model_name,

--- a/model_catalogs/model_catalogs/examples.py
+++ b/model_catalogs/model_catalogs/examples.py
@@ -75,7 +75,7 @@ def parse_bbox(val: str) -> Tuple[float, float, float, float]:
     values = val.split(',')
     if len(values) != 4:
         raise ValueError('bbox should include four numbers: lon_min,lat_min,lon_max,lat_max')
-    return tuple(*[float(i) for i in values])
+    return tuple(float(i) for i in values)
 
 
 def fetch(fetch_config):

--- a/model_catalogs/model_catalogs/examples.py
+++ b/model_catalogs/model_catalogs/examples.py
@@ -117,17 +117,27 @@ def parse_config(main,
                  default_bbox,
                  output_dir,
                  default_timing='hindcast',
-                 standard_names=None) -> FetchConfig:
+                 standard_names=None,
+                 default_start=None,
+                 default_end=None) -> FetchConfig:
     if standard_names is None:
         standard_names = STANDARD_NAMES
     parser = ArgumentParser(description=main.__doc__)
     parser.add_argument('-t',
                         '--timing',
                         choices=['hindcast', 'nowcast', 'forecast'],
-                        default='hindcast',
+                        default=default_timing,
                         help='Model Timing Choice.')
-    parser.add_argument('-s', '--start', type=pd.Timestamp, help='Request start time')
-    parser.add_argument('-e', '--end', type=pd.Timestamp, help='Request end time')
+    parser.add_argument('-s',
+                        '--start',
+                        type=pd.Timestamp,
+                        default=default_start,
+                        help='Request start time')
+    parser.add_argument('-e',
+                        '--end',
+                        type=pd.Timestamp,
+                        default=default_end,
+                        help='Request end time')
     parser.add_argument('-f', '--force', action='store_true', help='Overwrite existing files')
     parser.add_argument('--bbox',
                         type=parse_bbox,

--- a/model_catalogs/model_catalogs/examples.py
+++ b/model_catalogs/model_catalogs/examples.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+"""A module for common components for scripting examples."""
+import time
+from argparse import ArgumentParser
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+
+import model_catalogs as mc
+
+
+class Timer:
+    """A class to aid with measuring timing."""
+    def __init__(self, msg=None):
+        """Initializes the current time."""
+        self.t0 = time.time()
+        self.msg = msg
+
+    def tick(self):
+        """Update the timer start."""
+        self.t0 = time.time()
+
+    def tock(self) -> float:
+        """Return elapsed time in ms."""
+        return (time.time() - self.t0) * 1000.
+
+    def __enter__(self):
+        """With context."""
+        self.tick()
+
+    def __exit__(self, type, value, traceback):
+        """With exit."""
+        if self.msg is not None:
+            print(self.msg.format(self.tock()))
+
+
+STANDARD_NAMES = [
+    'eastward_sea_water_velocity',
+    'northward_sea_water_velocity',
+    'eastward_wind',
+    'northward_wind',
+    'sea_water_temperature',
+    'sea_water_practical_salinity',
+    'sea_floor_depth',
+]
+
+
+@dataclass
+class FetchConfig:
+    """Configuration data class for fetching."""
+    model_name: str
+    output_pth: Path
+    start: pd.Timestamp
+    end: pd.Timestamp
+    bbox: Tuple[float, float, float, float]
+    timing: str
+    standard_names: List[str] = field(default_factory=lambda : STANDARD_NAMES)
+
+
+def parse_bbox(val: str) -> Tuple[float, float, float, float]:
+    """Return the bounding box parsed from the comma-delimited string.
+
+    Parameters
+    ----------
+    val : str
+        Comma-delimited sequence of 4 float values for (lon_min, lat_min, lon_max, lat_max)
+
+    Returns
+    -------
+        tuple of 4 floats
+    """
+    values = val.split(',')
+    if len(values) != 4:
+        raise ValueError('bbox should include four numbers: lon_min,lat_min,lon_max,lat_max')
+    return tuple(*[float(i) for i in values])
+
+
+def fetch(fetch_config):
+    print('Setting up source catalog')
+    with Timer('\tSource catalog generated in {:.1f} ms'):
+        source_catalog = mc.setup_source_catalog()
+
+    print(f'Generating catalog specific for {fetch_config.model_name} {fetch_config.timing}')
+    with Timer('\tSpecific catalog generated in {:.1f} ms'):
+        catalog = mc.add_url_path(source_catalog[fetch_config.model_name],
+                                  timing=fetch_config.timing,
+                                  start_date=fetch_config.start,
+                                  end_date=fetch_config.end)
+    print('Getting xarray dataset for model data')
+    with Timer('\tCreated dask-based xarray dataset in {:.1f} ms'):
+        ds = catalog[fetch_config.model_name].to_dask()
+    print('Subsetting data')
+    with Timer('\tSubsetted dataset in {:.1f} ms'):
+        ds_ss = (
+            ds
+            .em.filter(fetch_config.standard_names)
+            .cf.sel(T=slice(fetch_config.start, fetch_config.end))
+            .em.sub_grid(bbox=fetch_config.bbox)
+        )
+        # TODO: This is going to get moved into model_catalogs, but some models from CO-OPS contain
+        #   a global attribute that originates from NETCDF3. However when xarray attempts to write
+        #   this special global attribute to disk, the netCDF-C library will throw an exception. See
+        #   https://github.com/pydata/xarray/issues/2822 for details.
+        if '_NCProperties' in ds_ss.attrs:
+            del ds_ss.attrs['_NCProperties']
+    print(f'Writing netCDF data to {fetch_config.output_pth}. This may take a long time...')
+    with Timer('\tWrote output to disk in {:.1f} ms'):
+        ds_ss.to_netcdf(fetch_config.output_pth)
+    print('Complete')
+
+
+def parse_config(main,
+                 model_name,
+                 default_bbox,
+                 output_dir,
+                 default_timing='hindcast',
+                 standard_names=None) -> FetchConfig:
+    if standard_names is None:
+        standard_names = STANDARD_NAMES
+    parser = ArgumentParser(description=main.__doc__)
+    parser.add_argument('-t',
+                        '--timing',
+                        choices=['hindcast', 'nowcast', 'forecast'],
+                        default='hindcast',
+                        help='Model Timing Choice.')
+    parser.add_argument('-s', '--start', type=pd.Timestamp, help='Request start time')
+    parser.add_argument('-e', '--end', type=pd.Timestamp, help='Request end time')
+    parser.add_argument('-f', '--force', action='store_true', help='Overwrite existing files')
+    parser.add_argument('--bbox',
+                        type=parse_bbox,
+                        default=default_bbox,
+                        help='Specify the bounding box')
+    args = parser.parse_args()
+
+    # Sanity check on start/end time
+    if args.start is None and args.end is None:
+        start = pd.Timestamp('2022-06-20')
+        end = pd.Timestamp('2022-06-21')
+    elif args.start is None or args.end is None:
+        raise ValueError('start time or end time not specified')
+    else:
+        start = args.start
+        end = args.end
+    if start >= end:
+        raise ValueError('end time must be greater than start time')
+
+    output_filename = (
+        f'{model_name}_{args.timing}_{start:%Y%m%d}-{end:%Y%m%d}.nc'
+    )
+    output_pth = output_dir / output_filename
+    if output_pth.exists():
+        if args.force:
+            output_pth.unlink()
+        else:
+            raise FileExistsError(f'{output_pth} already exists')
+
+    return FetchConfig(
+        model_name=model_name,
+        output_pth=output_pth,
+        start=start,
+        end=end,
+        bbox=args.bbox,
+        timing=args.timing,
+        standard_names=standard_names,
+    )

--- a/model_catalogs/model_catalogs/process.py
+++ b/model_catalogs/model_catalogs/process.py
@@ -46,7 +46,6 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
     Using supplied axis variable names and variable name mapping to associated
     standard names (from CF conventions), update the Dataset metadata.
     """
-
     # set standard_names for all variables
     for stan_name, var_names in standard_names.items():
         if not isinstance(var_names, list):
@@ -101,7 +100,7 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
     # decode times if times are floats.
     # Some datasets like GFS have multiple time coordinates for different phenomena like
     # precipitation accumulation vs winds vs surface albedo average.
-    if "T" in axis and len(axis["T"]) > 1:
+    if "T" in axis and isinstance(axis["T"], list) and len(axis["T"]) > 1:
         for time_var in axis["T"]:
             if ds[time_var].dtype == "float64":
                 ds = xr.decode_cf(ds, decode_times=True)

--- a/model_catalogs/model_catalogs/process.py
+++ b/model_catalogs/model_catalogs/process.py
@@ -65,8 +65,8 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
     # except Exception:
     #     pass
 
-    if metadata is not None and 'cf_coordinates' in metadata:
-        ds = ds.cf.set_coords(['longitude', 'latitude'])
+    if metadata is not None and 'coords' in metadata:
+        ds = ds.assign_coords({ k: ds[k] for k in metadata['coords'] })
 
     # set axis attributes (time, lon, lat, z potentially)
     for ax_name, var_names in axis.items():

--- a/model_catalogs/model_catalogs/process.py
+++ b/model_catalogs/model_catalogs/process.py
@@ -26,8 +26,8 @@ class DatasetTransform(GenericTransform):
         """Makes it so can read in model output."""
         if self._ds is None:
             self._pick()
-            kwargs = self._params['transform_kwargs']
-            kwargs['metadata'] = self.metadata
+            kwargs = self._params["transform_kwargs"]
+            kwargs["metadata"] = self.metadata
             self._ds = self._transform(
                 self._source.to_dask(),
                 **kwargs,
@@ -65,8 +65,8 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
     # except Exception:
     #     pass
 
-    if metadata is not None and 'coords' in metadata:
-        ds = ds.assign_coords({ k: ds[k] for k in metadata['coords'] })
+    if metadata is not None and "coords" in metadata:
+        ds = ds.assign_coords({k: ds[k] for k in metadata["coords"]})
 
     # set axis attributes (time, lon, lat, z potentially)
     for ax_name, var_names in axis.items():
@@ -101,9 +101,9 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
     # decode times if times are floats.
     # Some datasets like GFS have multiple time coordinates for different phenomena like
     # precipitation accumulation vs winds vs surface albedo average.
-    if 'T' in axis and len(axis['T']) > 1:
-        for time_var in axis['T']:
-            if ds[time_var].dtype == 'float64':
+    if "T" in axis and len(axis["T"]) > 1:
+        for time_var in axis["T"]:
+            if ds[time_var].dtype == "float64":
                 ds = xr.decode_cf(ds, decode_times=True)
                 break
     elif ds.cf["T"].dtype == "float64":
@@ -111,7 +111,7 @@ def add_attributes(ds, axis, standard_names, metadata: Optional[dict] = None):
 
     # This is an internal attribute used by netCDF which xarray doesn't know or care about, but can
     # be returned from THREDDS.
-    if '_NCProperties' in ds.attrs:
-        del ds.attrs['_NCProperties']
+    if "_NCProperties" in ds.attrs:
+        del ds.attrs["_NCProperties"]
 
     return ds

--- a/model_catalogs/model_catalogs/tests/test_examples.py
+++ b/model_catalogs/model_catalogs/tests/test_examples.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env pytest
-#-*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 """Unit tests for example support module."""
 from model_catalogs.examples import parse_bbox
 
 
 def test_bbox_parse():
     """Test that bbox can be parsed."""
-    bbox = parse_bbox('1,2,3,4')
+    bbox = parse_bbox("1,2,3,4")
     assert bbox == (1.0, 2.0, 3.0, 4.0)

--- a/model_catalogs/model_catalogs/tests/test_examples.py
+++ b/model_catalogs/model_catalogs/tests/test_examples.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env pytest
+#-*- coding: utf-8 -*-
+"""Unit tests for example support module."""
+from model_catalogs.examples import parse_bbox
+
+
+def test_bbox_parse():
+    """Test that bbox can be parsed."""
+    bbox = parse_bbox('1,2,3,4')
+    assert bbox == (1.0, 2.0, 3.0, 4.0)

--- a/scripts/examples/cbofs/fetch.py
+++ b/scripts/examples/cbofs/fetch.py
@@ -20,12 +20,12 @@ STANDARD_NAMES = [
     'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = (-76.5, 36.75, -75.25, 37.75)
+MODEL_NAME = 'CBOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch CBOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/dbofs/fetch.py
+++ b/scripts/examples/dbofs/fetch.py
@@ -20,12 +20,12 @@ STANDARD_NAMES = [
     'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = (-75.5, 38.5, -74.5, 39.25)
+MODEL_NAME = 'DBOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch DBOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/gfs-1deg/fetch.py
+++ b/scripts/examples/gfs-1deg/fetch.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+"""Download model data with catalog."""
+import sys
+import pandas as pd
+from pathlib import Path
+
+import extract_model  # noqa
+
+from model_catalogs.examples import fetch, parse_config
+
+STANDARD_NAMES = [
+    'wind_u',
+    'wind_v',
+    'longitude',
+    'latitude',
+]
+
+DEFAULT_BBOX = (275., 25., 300., 48.)
+MODEL_NAME = 'GFS-1DEG'
+
+
+def main():
+    """Fetch DBOFS Model Data."""
+    # Check output
+    output_dir = Path(__file__).parent / 'output'
+    if not output_dir.exists():
+        output_dir.mkdir()
+
+    default_start = (pd.Timestamp.today() - pd.Timedelta('1D')).floor('1D') 
+    default_end = default_start + pd.Timedelta('1D')
+
+    config = parse_config(main=main,
+                          model_name=MODEL_NAME,
+                          default_bbox=DEFAULT_BBOX,
+                          output_dir=output_dir,
+                          default_timing='forecast',
+                          standard_names=STANDARD_NAMES,
+                          default_start=default_start,
+                          default_end=default_end)
+    fetch(config)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/examples/loofs/fetch.py
+++ b/scripts/examples/loofs/fetch.py
@@ -20,12 +20,12 @@ STANDARD_NAMES = [
     'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = (-78.6, 43.4, -77.1, 43.7)
+MODEL_NAME = 'LOOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch LOOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/lsofs/fetch.py
+++ b/scripts/examples/lsofs/fetch.py
@@ -16,16 +16,14 @@ STANDARD_NAMES = [
     'sea_water_temperature',
     'sea_water_practical_salinity',
     'sea_floor_depth',
-    'longitude',
-    'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = (-89.4, 47.0, -86.4, 47.75)
+MODEL_NAME = 'LSOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch LSOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/nyofs/fetch.py
+++ b/scripts/examples/nyofs/fetch.py
@@ -16,16 +16,14 @@ STANDARD_NAMES = [
     'sea_water_temperature',
     'sea_water_practical_salinity',
     'sea_floor_depth',
-    'longitude',
-    'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = bbox = (-74.1, 40.49, -73.95, 40.61)
+MODEL_NAME = 'NYOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch NYOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/tbofs/fetch.py
+++ b/scripts/examples/tbofs/fetch.py
@@ -20,12 +20,12 @@ STANDARD_NAMES = [
     'latitude',
 ]
 
-DEFAULT_BBOX = (-154.5, 58., -151., 60.)
-MODEL_NAME = 'CIOFS'
+DEFAULT_BBOX = bbox = (-82.9, 27.3, -82.6, 27.7)
+MODEL_NAME = 'TBOFS'
 
 
 def main():
-    """Fetch CIOFS Model Data."""
+    """Fetch TBOFS Model Data."""
     # Check output
     output_dir = Path(__file__).parent / 'output'
     if not output_dir.exists():

--- a/scripts/examples/wcofs/fetch.py
+++ b/scripts/examples/wcofs/fetch.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+"""Download model data with catalog."""
+import sys
+from pathlib import Path
+
+import extract_model  # noqa
+
+from model_catalogs.examples import fetch, parse_config
+
+STANDARD_NAMES = [
+    'eastward_sea_water_velocity',
+    'northward_sea_water_velocity',
+    'eastward_wind',
+    'northward_wind',
+    'sea_water_temperature',
+    'sea_water_practical_salinity',
+    'sea_floor_depth',
+    'longitude',
+    'latitude',
+]
+
+DEFAULT_BBOX = (-122.0, 25.0, -115., 35.)
+MODEL_NAME = 'WCOFS'
+
+
+def main():
+    """Fetch WCOFS Model Data."""
+    # Check output
+    output_dir = Path(__file__).parent / 'output'
+    if not output_dir.exists():
+        output_dir.mkdir()
+
+    config = parse_config(main=main,
+                          model_name=MODEL_NAME,
+                          default_bbox=DEFAULT_BBOX,
+                          output_dir=output_dir,
+                          default_timing='hindcast',
+                          standard_names=STANDARD_NAMES)
+    fetch(config)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/examples/wcofs_2ds/fetch.py
+++ b/scripts/examples/wcofs_2ds/fetch.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+#-*- coding: utf-8 -*-
+"""Download model data with catalog."""
+import sys
+from pathlib import Path
+
+import extract_model  # noqa
+
+from model_catalogs.examples import fetch, parse_config
+
+STANDARD_NAMES = [
+    'eastward_sea_water_velocity',
+    'northward_sea_water_velocity',
+    'eastward_wind',
+    'northward_wind',
+    'sea_water_temperature',
+    'sea_water_practical_salinity',
+    'sea_floor_depth',
+    'longitude',
+    'latitude',
+]
+
+DEFAULT_BBOX = (-122.0, 25.0, -115., 35.)
+MODEL_NAME = 'WCOFS_2DS'
+
+
+def main():
+    """Fetch WCOFS Model Data."""
+    # Check output
+    output_dir = Path(__file__).parent / 'output'
+    if not output_dir.exists():
+        output_dir.mkdir()
+
+    config = parse_config(main=main,
+                          model_name=MODEL_NAME,
+                          default_bbox=DEFAULT_BBOX,
+                          output_dir=output_dir,
+                          default_timing='hindcast',
+                          standard_names=STANDARD_NAMES)
+    fetch(config)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This commit adds the fetch implementation for each of the NOAA OFS
models that don't rely on a triangular mesh. This commit also makes
changess to the process module to support the case where POM model
output doesn't have coordinates interpreted by xarray correctly.