### PR TITLE
Static tests

### DIFF
--- a/model_catalogs/.gitattributes
+++ b/model_catalogs/.gitattributes
@@ -1,0 +1,1 @@
+*.nc filter=lfs diff=lfs merge=lfs -text

--- a/model_catalogs/model_catalogs/__init__.py
+++ b/model_catalogs/model_catalogs/__init__.py
@@ -14,6 +14,7 @@ from .model_catalogs import (  # noqa
     find_availability,
     make_catalog,
     setup_source_catalog,
+    transform_source,
 )
 from .utils import (  # noqa
     agg_for_date,

--- a/model_catalogs/model_catalogs/catalogs/orig/cbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/cbofs.yaml
@@ -53,10 +53,20 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: null
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
+      # these will fill in `tod` parameter to provide 2 sample file locations for output
+      # only recent output is available so have to use a variable date
+      sample_locs: ["https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       output_period_(hr): 1
+      # thredds catalog url
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time.'
       axis:
@@ -94,10 +104,12 @@ sources:
       urlpath: null
     metadata:
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-cbofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-cbofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-01. Stations files are inconsistently available back into 2014.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-cbofs-files/2022/07/nos.cbofs.fields.n001.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-cbofs-files/2022/07/nos.cbofs.fields.n001.20220701.t06z.nc"]
       axis:
         T: ocean_time
         X: [xi_rho, xi_u, xi_v, xi_psi]

--- a/model_catalogs/model_catalogs/catalogs/orig/cbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/cbofs.yaml
@@ -52,7 +52,9 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: ["https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
     parameters:
       tod:
         description: Pandas like Timestamp for today

--- a/model_catalogs/model_catalogs/catalogs/orig/cbofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/cbofs_regulargrid.yaml
@@ -11,7 +11,7 @@ metadata:
 sources:
   forecast:
     driver: opendap
-    description: 3D Chesapeake Bay model in ROMS, interpolated to regular grid, from 1 day ago until present day. Only nowcast files are used in aggregation. Same as nowcast.
+    description: 3D Chesapeake Bay model in ROMS, interpolated to regular grid, from 1 day ago until present day. Only nowcast files are used in aggregation.
     args:
       chunks:
         ocean_time: 1
@@ -21,8 +21,7 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      urlpath: ["https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.regulargrid.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
       ]
     parameters:
@@ -31,41 +30,12 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
+      # these will fill in `tod` parameter to provide 2 sample file locations for output
+      # only recent output is available so have to use a variable date
+      sample_locs: ["https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.cbofs.regulargrid.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-
-  nowcast:
-    driver: opendap
-    description: 3D Chesapeake Bay model in ROMS, interpolated to regular grid, from 1 day ago until present day. Only nowcast files are used in aggregation. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/ciofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ciofs.yaml
@@ -52,7 +52,15 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
       sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",

--- a/model_catalogs/model_catalogs/catalogs/orig/ciofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ciofs.yaml
@@ -54,8 +54,11 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1
@@ -93,8 +96,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-ciofs-files/2022/07/nos.ciofs.fields.n001.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-ciofs-files/2022/07/nos.ciofs.fields.n001.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ciofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ciofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-01. Stations files are inconsistently available back into 2014.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/ciofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ciofs_regulargrid.yaml
@@ -11,7 +11,7 @@ metadata:
 sources:
   forecast:
     driver: opendap
-    description: 3D Cook Inlet model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as nowcast.
+    description: 3D Cook Inlet model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -31,41 +31,11 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CIOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ciofs.regulargrid.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-
-  nowcast:
-    driver: opendap
-    description: 3D Cook Inlet model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CIOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/creofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/creofs.yaml
@@ -14,7 +14,7 @@ sources:
     args:
       chunks:
         time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      # drop_variables: ['siglay','siglev','Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -32,48 +32,17 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1
       axis:
         T: time
-        Z: z_val
-      standard_names:
-        eastward_sea_water_velocity: u
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v
-        northward_wind: vwind_speed
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salinity
-        time: time
-
-  nowcast:
-    description: Columbia River model in SELFE from 30 days ago with 48 hour forecast (identical to forecast).
-    args:
-      chunks:
-        time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: time
-        Z: z_val
+        Z: zval
       standard_names:
         eastward_sea_water_velocity: u
         eastward_wind: uwind_speed
@@ -91,7 +60,7 @@ sources:
     args:
       chunks:
         ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      # drop_variables: ['siglay','siglev','Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -100,14 +69,16 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-creofs-files/2022/07/nos.creofs.fields.n000.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-creofs-files/2022/07/nos.creofs.fields.n000.20220701.t09z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-creofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-creofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-19'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1
       axis:
         T: time
-        Z: z_val
+        Z: zval
       standard_names:
         eastward_sea_water_velocity: u
         eastward_wind: uwind_speed

--- a/model_catalogs/model_catalogs/catalogs/orig/creofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/creofs.yaml
@@ -14,7 +14,6 @@ sources:
     args:
       chunks:
         time: 1
-      # drop_variables: ['siglay','siglev','Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -42,7 +41,7 @@ sources:
       output_period_(hr): 1
       axis:
         T: time
-        Z: zval
+        Z: nv
       standard_names:
         eastward_sea_water_velocity: u
         eastward_wind: uwind_speed
@@ -53,6 +52,11 @@ sources:
         sea_water_temperature: temp
         sea_water_practical_salinity: salinity
         time: time
+      coords:
+        - time
+        - zval
+        - lat
+        - lon
 
   hindcast:
     driver: opendap
@@ -60,7 +64,6 @@ sources:
     args:
       chunks:
         ocean_time: 1
-      # drop_variables: ['siglay','siglev','Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -78,7 +81,7 @@ sources:
       output_period_(hr): 1
       axis:
         T: time
-        Z: zval
+        Z: nv
       standard_names:
         eastward_sea_water_velocity: u
         eastward_wind: uwind_speed
@@ -89,3 +92,8 @@ sources:
         sea_water_temperature: temp
         sea_water_practical_salinity: salinity
         time: time
+      coords:
+        - time
+        - zval
+        - lat
+        - lon

--- a/model_catalogs/model_catalogs/catalogs/orig/creofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/creofs_regulargrid.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: Columbia River model in SELFE, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as nowcast.
+    description: Columbia River model in SELFE, interpolated to regular grid, from 1 day ago with 48 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -22,8 +22,8 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
     parameters:
       tod:
@@ -32,49 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    description: Columbia River model in SELFE, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/CREOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.creofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    driver: opendap
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/CREOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/dbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/dbofs.yaml
@@ -53,9 +53,17 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: null
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       filetype: ['fields']
@@ -93,8 +101,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-dbofs-files/2022/07/nos.dbofs.fields.n001.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-dbofs-files/2022/07/nos.dbofs.fields.n001.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-dbofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-dbofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-01. Stations files are inconsistently available back into 2014.'
       overall_end_datetime: 'Available through 4 days before present time'
       filetype: ['fields']

--- a/model_catalogs/model_catalogs/catalogs/orig/dbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/dbofs.yaml
@@ -52,7 +52,10 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
     parameters:
       tod:
         description: Pandas like Timestamp for today

--- a/model_catalogs/model_catalogs/catalogs/orig/dbofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/dbofs_regulargrid.yaml
@@ -11,7 +11,7 @@ metadata:
 sources:
   forecast:
     driver: opendap
-    description: 3D Delaware Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as nowcast.
+    description: 3D Delaware Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -31,40 +31,11 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/DBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.dbofs.regulargrid.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    driver: opendap
-    description: 3D Delaware Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/DBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/gfs-1_2deg.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gfs-1_2deg.yaml
@@ -21,6 +21,18 @@ sources:
       overall_end_datetime: '16 days from today.'
       output_period_(hr): 3
       axis:
-        T: ['time', 'time2', 'time1', 'time3']
+        # time is for instantaneous variables which are most
+        # time2 is the time dimension for averaged variables
+        # time3 is for precipitation accumulation variables
+        T: ['time', 'time1', 'time2', 'time3']
+        Y: lat
+        X: lon
       standard_names:
+        air_temperature: Temperature_height_above_ground
+        dew_point_temperature: Dewpoint_temperature_height_above_ground
+        eastward_wind: u-component_of_wind_height_above_ground
+        latitude: lat
+        longitude: lon
+        northward_wind: v-component_of_wind_height_above_ground
         time: time
+        wind_gust: Wind_speed_gust_surface

--- a/model_catalogs/model_catalogs/catalogs/orig/gfs-1_4deg.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gfs-1_4deg.yaml
@@ -21,6 +21,18 @@ sources:
       overall_end_datetime: '16 days from today.'
       output_period_(hr): 3
       axis:
-        T: ['time', 'time2', 'time1', 'time3']
+        # time is for instantaneous variables which are most
+        # time2 is the time dimension for averaged variables
+        # time3 is for precipitation accumulation variables
+        T: ['time', 'time1', 'time2', 'time3']
+        Y: lat
+        X: lon
       standard_names:
+        air_temperature: Temperature_height_above_ground
+        dew_point_temperature: Dewpoint_temperature_height_above_ground
+        eastward_wind: u-component_of_wind_height_above_ground
+        latitude: lat
+        longitude: lon
+        northward_wind: v-component_of_wind_height_above_ground
         time: time
+        wind_gust: Wind_speed_gust_surface

--- a/model_catalogs/model_catalogs/catalogs/orig/gfs-1deg.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gfs-1deg.yaml
@@ -24,13 +24,15 @@ sources:
         # time is for instantaneous variables which are most
         # time2 is the time dimension for averaged variables
         # time3 is for precipitation accumulation variables
-        T: ['time', 'time2', 'time1', 'time3']
+        T: ['time', 'time1', 'time2', 'time3']
+        Y: lat
+        X: lon
       standard_names:
-        time: time
         air_temperature: Temperature_height_above_ground
-        wind_u: u-component_of_wind_height_above_ground
-        wind_v: v-component_of_wind_height_above_ground
-        wind_gust: Wind_speed_gust_surface
         dew_point_temperature: Dewpoint_temperature_height_above_ground
-        longitude: lon
+        eastward_wind: u-component_of_wind_height_above_ground
         latitude: lat
+        longitude: lon
+        northward_wind: v-component_of_wind_height_above_ground
+        time: time
+        wind_gust: Wind_speed_gust_surface

--- a/model_catalogs/model_catalogs/catalogs/orig/gomofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gomofs.yaml
@@ -54,8 +54,11 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 3
@@ -93,8 +96,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-gomofs-files/2022/07/nos.gomofs.fields.n003.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-gomofs-files/2022/07/nos.gomofs.fields.n003.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-gomofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-gomofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2018-05-10. Also available inconsistently to the beginning of 2018.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/catalogs/orig/gomofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gomofs.yaml
@@ -52,7 +52,15 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
       sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",

--- a/model_catalogs/model_catalogs/catalogs/orig/gomofs_2ds.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gomofs_2ds.yaml
@@ -11,7 +11,7 @@ metadata:
 sources:
   forecast:
     driver: opendap
-    description: 3D Gulf of Maine model in ROMS, 2D variables, from 30 days ago with 72 hour forecast. Same as nowcast.
+    description: 3D Gulf of Maine model in ROMS, 2D variables, from 30 days ago with 72 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -31,51 +31,11 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 72 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: [xi_rho, xi_u, xi_v, xi_psi]
-        Y: [eta_rho, eta_u, eta_v, eta_psi]
-        Z: [z_rho, z_w]
-      standard_names:
-        eastward_sea_water_velocity: u_sur
-        eastward_wind: Uwind
-        northward_sea_water_velocity: v_sur
-        northward_wind: Vwind
-        ocean_s_coordinate_g2: [s_rho, s_w]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp_sur
-        sea_water_practical_salinity: salt_sur
-        time: ocean_time
-  nowcast:
-    driver: opendap
-    description: 3D Gulf of Maine model in ROMS, 2D variables, from 30 days ago with 72 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
+      sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.2ds.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 1
@@ -112,8 +72,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-gomofs-files/2022/07/nos.gomofs.2ds.n001.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-gomofs-files/2022/07/nos.gomofs.2ds.n001.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-gomofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-gomofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2018-05-10. Also available inconsistently to the beginning of 2018.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/gomofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/gomofs_regulargrid.yaml
@@ -9,41 +9,9 @@ metadata:
   filetype: 'regulargrid'
 
 sources:
-  nowcast:
-    driver: opendap
-    description: 3D Gulf of Maine model in ROMS, interpolated to regular grid, from 1 day ago with 72 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 72 hours after present time'
-      output_period_(hr): 3
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
   forecast:
     driver: opendap
-    description: 3D Gulf of Maine model in ROMS, interpolated to regular grid, from 1 day ago with 72 hour forecast. Same as nowcast.
+    description: 3D Gulf of Maine model in ROMS, interpolated to regular grid, from 1 day ago with 72 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -63,8 +31,11 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.regulargrid.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/GOMOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.gomofs.regulargrid.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/GOMOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/catalogs/orig/leofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/leofs.yaml
@@ -32,42 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 120 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: time
-      standard_names:
-        eastward_sea_water_velocity: u
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v
-        northward_wind: vwind_speed
-        ocean_sigma_coordinate: [siglay, siglev]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salinity
-        time: time
-
-  nowcast:
-    description: Lake Erie model in FVCOM from 30 days ago with 120 hour forecast (identical to forecast).
-    args:
-      chunks:
-        ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 120 hours after present time'
       output_period_(hr): 1
@@ -100,8 +69,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-leofs-files/2022/07/nos.leofs.fields.n000.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-leofs-files/2022/07/nos.leofs.fields.n000.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-leofs/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-leofs/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2016-03-10'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/leofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/leofs_regulargrid.yaml
@@ -10,11 +10,11 @@ metadata:
 
 sources:
   forecast:
-    description: Lake Erie model in FVCOM, interpolated to regular grid, from 1 day ago with 120 hour forecast. Same as nowcast.
+    description: Lake Erie model in FVCOM, interpolated to regular grid, from 1 day ago with 120 hour forecast.
     args:
       chunks:
         ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      drop_variables: ['Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -22,51 +22,21 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
       ]
+    driver: opendap
     parameters:
       tod:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
-    driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LEOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.leofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 120 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    description: Lake Erie model in FVCOM, interpolated to regular grid, from 1 day ago with 120 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LEOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 120 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/lmhofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lmhofs.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: Lake Michigan and Huron model in FVCOM from 30 days ago with 120 hour forecast. Same as nowcast.
+    description: Lake Michigan and Huron model in FVCOM from 30 days ago with 120 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -32,42 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LMHOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.lmhofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LMHOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.lmhofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available a month before present day.'
-      overall_end_datetime: 'Available through 120 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: time
-      standard_names:
-        eastward_sea_water_velocity: u
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v
-        northward_wind: vwind_speed
-        ocean_sigma_coordinate: [siglay, siglev]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salinity
-        time: time
-
-  nowcast:
-    description: Lake Michigan and Huron model in FVCOM from 30 days ago with 120 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available a month before present day.'
       overall_end_datetime: 'Available through 120 hours after present time'
       output_period_(hr): 1
@@ -100,8 +69,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-lmhofs-files/2022/07/nos.lmhofs.fields.n000.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-lmhofs-files/2022/07/nos.lmhofs.fields.n000.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-lmhofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-lmhofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2019-09-17'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/lmhofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lmhofs_regulargrid.yaml
@@ -32,8 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LMHOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.lmhofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LMHOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.lmhofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LMHOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 120 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
@@ -55,7 +55,15 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LOOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.loofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LOOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.loofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t06z.nc",
+      ]
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
       sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LOOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.loofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",

--- a/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/loofs.yaml
@@ -52,8 +52,11 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LOOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.loofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LOOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.loofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t06z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LOOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LOOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 120 hours after present time.'
       notes: 'treat_last_day_as_forecast==True will not work here'
@@ -89,8 +92,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-loofs-files/2022/07/glofs.loofs.fields.nowcast.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-loofs-files/2022/07/glofs.loofs.fields.nowcast.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-loofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-loofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2016-03-01.'
       overall_end_datetime: 'Available through 4 days before present time.'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
@@ -53,8 +53,11 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LSOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.lsofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LSOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.lsofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t06z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LSOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/LSOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 120 hours after present time.'
       notes: 'treat_last_day_as_forecast==True will not work here'
@@ -92,8 +95,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-lsofs-files/2022/07/glofs.lsofs.fields.nowcast.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-lsofs-files/2022/07/glofs.lsofs.fields.nowcast.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-lsofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-lsofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2016-03-06.'
       overall_end_datetime: 'Available through 4 days before present time.'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/lsofs.yaml
@@ -56,7 +56,15 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LSOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.lsofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LSOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.lsofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t06z.nc",
+      ]
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
       sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/LSOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/glofs.lsofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",

--- a/model_catalogs/model_catalogs/catalogs/orig/ngofs2.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ngofs2.yaml
@@ -32,42 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 54 hours after present time'
-      output_period_(hr): 3
-      axis:
-        T: time
-      standard_names:
-        eastward_sea_water_velocity: u
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v
-        northward_wind: vwind_speed
-        ocean_sigma_coordinate: [siglay, siglev]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salinity
-        time: time
-
-  nowcast:
-    description: Northern Gulf of Mexico model in FVCOM from 30 days ago with 54 hour forecast (identical to forecast).
-    args:
-      chunks:
-        time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 54 hours after present time'
       output_period_(hr): 3
@@ -100,8 +69,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-ngofs2-files/2022/07/nos.ngofs2.fields.n000.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-ngofs2-files/2022/07/nos.ngofs2.fields.n000.20220701.t09z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ngofs2-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ngofs2-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2021-03-22.'
       overall_end_datetime: 'Available through 4 days before present time.'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/catalogs/orig/ngofs2_2ds.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ngofs2_2ds.yaml
@@ -25,15 +25,18 @@ sources:
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
+    driver: opendap
     parameters:
       tod:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
-    driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 54 hours after present time'
       output_period_(hr): 1
@@ -62,19 +65,19 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      ]
+      urlpath: null
+    driver: opendap
     parameters:
       tod:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
-    driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 54 hours after present time'
       output_period_(hr): 1
@@ -106,8 +109,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-ngofs2-files/2022/07/nos.ngofs2.2ds.n000.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-ngofs2-files/2022/07/nos.ngofs2.2ds.n000.20220701.t09z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ngofs2-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-ngofs2-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2021-03-22'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/ngofs2_2ds.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ngofs2_2ds.yaml
@@ -10,11 +10,12 @@ metadata:
 
 sources:
   forecast:
-    description: Northern Gulf of Mexico model in FVCOM from 30 days ago with 54 hour forecast. Same as nowcast.
+    description: Northern Gulf of Mexico model in FVCOM from 30 days ago with 54 hour forecast.
     args:
       chunks:
         time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      drop_variables: ['Itime2']
+      # drop_variables: ['siglay','siglev','Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -25,47 +26,6 @@ sources:
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    driver: opendap
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    metadata:
-      sample_locs: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      ]
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 54 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: time
-      standard_names:
-        eastward_sea_water_velocity: u_surface
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v_surface
-        northward_wind: vwind_speed
-        ocean_sigma_coordinate: [siglay, siglev]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp_surface
-        sea_water_practical_salinity: salinity_surface
-        time: time
-  nowcast:
-    description: Northern Gulf of Mexico model in FVCOM from 30 days ago with 54 hour forecast. Same as forecast.
-    args:
-      chunks:
-        time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
     driver: opendap
     parameters:
       tod:

--- a/model_catalogs/model_catalogs/catalogs/orig/ngofs2_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ngofs2_regulargrid.yaml
@@ -14,7 +14,7 @@ sources:
     args:
       chunks:
         ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      drop_variables: ['Itime2']
       compat: override
       combine: by_coords
       parallel: True

--- a/model_catalogs/model_catalogs/catalogs/orig/ngofs2_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/ngofs2_regulargrid.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: Northern Gulf of Mexico model in FVCOM, interpolated to regular grid, from 1 day ago with 54 hour forecast. Same as nowcast.
+    description: Northern Gulf of Mexico model in FVCOM, interpolated to regular grid, from 1 day ago with 54 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -32,49 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 54 hours after present time'
-      output_period_(hr): 3
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    description: Northern Gulf of Mexico model in FVCOM, interpolated to regular grid, from 1 day ago with 54 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NGOFS2/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.ngofs2.regulargrid.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    driver: opendap
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NGOFS2/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 54 hours after present time'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
@@ -54,8 +54,20 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NYOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.nyofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t05z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NYOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.nyofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t11z.nc",
+      ]
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NYOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.nyofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t05z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/NYOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.nyofs.fields.nowcast.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t11z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NYOFS/MODELS/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
@@ -97,8 +109,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-nyofs-files/2022/07/nos.nyofs.fields.nowcast.20220701.t05z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-nyofs-files/2022/07/nos.nyofs.fields.nowcast.20220701.t11z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-nyofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-nyofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-19. Stations files are inconsistently available back into 2014.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/nyofs.yaml
@@ -52,7 +52,6 @@ sources:
       urlpath: null
     metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NYOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/NYOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       pattern: '*.nyofs.{filetype}.n*.{date.year}{str(date.month).zfill(2)}{str(date.day).zfill(2)}.t??z.*'

--- a/model_catalogs/model_catalogs/catalogs/orig/rtofs-alaska.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/rtofs-alaska.yaml
@@ -8,7 +8,49 @@ metadata:
   filetype: 'fields'
 
 sources:
+
   forecast:
+    driver: opendap
+    description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for Alaska from 2 days ago through 5 day forecast.
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+    args:
+      chunks:
+        time: 1
+      compat: override
+      combine: by_coords
+      parallel: True
+      data_vars: minimal
+      coords: minimal
+      engine: netcdf4
+      urlpath: [
+      "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_ak",
+      "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_ak",
+      ]
+    metadata:
+      overall_start_datetime: '2 days before present day.'
+      overall_end_datetime: '5 days after present day'
+      output_period_(hr): 6
+      axis:
+        T: time
+        X: lon
+        Y: lat
+        Z: lev
+      standard_names:
+        eastward_sea_water_velocity: u
+        northward_sea_water_velocity: v
+        sea_water_temperature: temperature
+        sea_water_practical_salinity: salinity
+        time: time
+
+  # the necessary files are only available starting partway through the day
+  nowcast:
     driver: opendap
     description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for Alaska from yesterday through 5 day forecast.
     parameters:
@@ -16,6 +58,9 @@ sources:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
     args:
       chunks:
         time: 1
@@ -44,34 +89,3 @@ sources:
         sea_water_temperature: temperature
         sea_water_practical_salinity: salinity
         time: time
-
-  # nowcast:
-  #   driver: opendap
-  #   description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for Alaska from 2 days ago through 5 day forecast.
-  #   parameters:
-  #     tod:
-  #       description: Pandas like Timestamp for today
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       default: today
-  #     yesterday:
-  #       description: Pandas like Timestamp for yesterday
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       # default: today
-  #   args:
-  #     chunks:
-  #       time: 1
-  #     # drop_variables: ['ocean_time']
-  #     compat: override
-  #     combine: by_coords
-  #     parallel: True
-  #     data_vars: minimal
-  #     coords: minimal
-  #     engine: netcdf4
-  #     urlpath: [
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_ak",
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_ak",
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_ak",
-  #     ]
-  #   metadata:
-  #     overall_start_datetime: '2 days before present day.'
-  #     overall_end_datetime: '5 days after present day'

--- a/model_catalogs/model_catalogs/catalogs/orig/rtofs-east.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/rtofs-east.yaml
@@ -8,7 +8,53 @@ metadata:
   filetype: 'fields'
 
 sources:
+
   forecast:
+    driver: opendap
+    description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. East Coast from 2 days ago through 5 day forecast.
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        # default: today
+    args:
+      chunks:
+        time: 1
+      # drop_variables: ['ocean_time']
+      compat: override
+      combine: by_coords
+      parallel: True
+      data_vars: minimal
+      coords: minimal
+      engine: netcdf4
+      urlpath: [
+      "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_east",
+      "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_us_east",
+      # "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_east",
+      # "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_us_east",
+      ]
+    metadata:
+      overall_start_datetime: '2 days ago.'
+      overall_end_datetime: '5 days after present day'
+      output_period_(hr): 6
+      axis:
+        T: time
+        X: lon
+        Y: lat
+        Z: lev
+      standard_names:
+        eastward_sea_water_velocity: u
+        northward_sea_water_velocity: v
+        sea_water_temperature: temperature
+        sea_water_practical_salinity: salinity
+        time: time
+
+  # the necessary files are only available starting partway through the day
+  nowcast:
     driver: opendap
     description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. East Coast from yesterday through 5 day forecast.
     parameters:
@@ -16,6 +62,9 @@ sources:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
     args:
       chunks:
         time: 1
@@ -45,34 +94,3 @@ sources:
         sea_water_temperature: temperature
         sea_water_practical_salinity: salinity
         time: time
-
-  # nowcast:
-  #   driver: opendap
-  #   description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. East Coast from 2 days ago through 5 day forecast.
-  #   parameters:
-  #     tod:
-  #       description: Pandas like Timestamp for today
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       default: today
-  #     yesterday:
-  #       description: Pandas like Timestamp for yesterday
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       # default: today
-  #   args:
-  #     chunks:
-  #       time: 1
-  #     # drop_variables: ['ocean_time']
-  #     compat: override
-  #     combine: by_coords
-  #     parallel: True
-  #     data_vars: minimal
-  #     coords: minimal
-  #     engine: netcdf4
-  #     urlpath: [
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_east",
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_east",
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_us_east",
-  #     ]
-  #   metadata:
-  #     overall_start_datetime: '2 days ago.'
-  #     overall_end_datetime: '5 days after present day'

--- a/model_catalogs/model_catalogs/catalogs/orig/rtofs-west.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/rtofs-west.yaml
@@ -8,7 +8,52 @@ metadata:
   filetype: 'fields'
 
 sources:
+
   forecast:
+    driver: opendap
+    description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. West Coast from 2 days ago through 5 day forecast.
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        # default: today
+    args:
+      chunks:
+        time: 1
+      # drop_variables: ['ocean_time']
+      compat: override
+      combine: by_coords
+      parallel: True
+      data_vars: minimal
+      coords: minimal
+      engine: netcdf4
+      urlpath: [
+      "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_west",
+      # "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_us_west",
+      ]
+    metadata:
+      overall_start_datetime: 'Two days ago.'
+      overall_end_datetime: '5 days after present day.'
+      notes: the forecast link is returning East Coast RTOFS data currently.
+      output_period_(hr): 6
+      axis:
+        T: time
+        X: lon
+        Y: lat
+        Z: lev
+      standard_names:
+        eastward_sea_water_velocity: u
+        northward_sea_water_velocity: v
+        sea_water_temperature: temperature
+        sea_water_practical_salinity: salinity
+        time: time
+
+  # the necessary files are only available starting partway through the day
+  nowcast:
     driver: opendap
     description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. West Coast from yesterday through 5 day forecast.
     parameters:
@@ -16,6 +61,9 @@ sources:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
+      yesterday:
+        description: Pandas like Timestamp for yesterday
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
     args:
       chunks:
         time: 1
@@ -45,35 +93,3 @@ sources:
         sea_water_temperature: temperature
         sea_water_practical_salinity: salinity
         time: time
-
-  # nowcast:
-  #   driver: opendap
-  #   description: 6-hourly 3D Real-Time Ocean Forecast System model in HYCOM for the U.S. West Coast from 2 days ago through 5 day forecast.
-  #   parameters:
-  #     tod:
-  #       description: Pandas like Timestamp for today
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       default: today
-  #     yesterday:
-  #       description: Pandas like Timestamp for yesterday
-  #       type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-  #       # default: today
-  #   args:
-  #     chunks:
-  #       time: 1
-  #     # drop_variables: ['ocean_time']
-  #     compat: override
-  #     combine: by_coords
-  #     parallel: True
-  #     data_vars: minimal
-  #     coords: minimal
-  #     engine: netcdf4
-  #     urlpath: [
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ yesterday.year }}{{ yesterday.strftime('%m') }}{{ yesterday.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_west",
-  #     "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_nowcast_6hrly_us_west",
-  #     # "https://nomads.ncep.noaa.gov/dods/rtofs/rtofs_global{{ tod.year }}{{ tod.strftime('%m') }}{{ tod.strftime('%d') }}/rtofs_glo_3dz_forecast_6hrly_us_west",
-  #     ]
-  #   metadata:
-  #     overall_start_datetime: 'Two days ago.'
-  #     overall_end_datetime: '5 days after present day.'
-  #     notes: the forecast link is returning East Coast RTOFS data currently.

--- a/model_catalogs/model_catalogs/catalogs/orig/sfbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/sfbofs.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: San Francisco Bay model in FVCOM from 30 days ago with 48 hour forecast. Same as nowcast.
+    description: San Francisco Bay model in FVCOM from 30 days ago with 48 hour forecast.
     args:
       chunks:
         time: 1
@@ -32,42 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/SFBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.sfbofs.fields.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/SFBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.sfbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: time
-      standard_names:
-        eastward_sea_water_velocity: u
-        eastward_wind: uwind_speed
-        northward_sea_water_velocity: v
-        northward_wind: vwind_speed
-        ocean_sigma_coordinate: [siglay, siglev]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salinity
-        time: time
-
-  nowcast:
-    description: San Francisco Bay model in FVCOM from 30 days ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        time: 1
-      drop_variables: ['siglay','siglev','Itime2']
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1
@@ -100,8 +69,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-sfbofs-files/2022/07/nos.sfbofs.fields.n000.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-sfbofs-files/2022/07/nos.sfbofs.fields.n000.20220701.t09z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-sfbofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-sfbofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-19'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/sfbofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/sfbofs_regulargrid.yaml
@@ -10,11 +10,11 @@ metadata:
 
 sources:
   forecast:
-    description: San Francisco Bay model in FVCOM, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as nowcast.
+    description: San Francisco Bay model in FVCOM, interpolated to regular grid, from 1 day ago with 48 hour forecast.
     args:
       chunks:
         ocean_time: 1
-      drop_variables: ['siglay','siglev','Itime2']
+      drop_variables: ['Itime2']
       compat: override
       combine: by_coords
       parallel: True
@@ -32,49 +32,11 @@ sources:
         default: today
     driver: opendap
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    description: San Francisco Bay model in FVCOM, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      drop_variables: ['siglay','siglev','Itime2']
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
+      sample_locs: [
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/SFBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.sfbofs.regulargrid.n000.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/SFBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.sfbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    driver: opendap
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/SFBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/tbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/tbofs.yaml
@@ -52,7 +52,10 @@ sources:
       data_vars: minimal
       coords: minimal
       engine: netcdf4
-      urlpath: null
+      urlpath: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
     parameters:
       tod:
         description: Pandas like Timestamp for today

--- a/model_catalogs/model_catalogs/catalogs/orig/tbofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/tbofs.yaml
@@ -53,9 +53,17 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: null
+    parameters:
+      tod:
+        description: Pandas like Timestamp for today
+        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
+        default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.fields.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.fields.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1
@@ -92,8 +100,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-tbofs-files/2022/07/nos.tbofs.fields.n001.20220701.t00z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-tbofs-files/2022/07/nos.tbofs.fields.n001.20220701.t06z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-tbofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-tbofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2015-08-01. Stations files are inconsistently available back into 2014.'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/tbofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/tbofs_regulargrid.yaml
@@ -11,7 +11,7 @@ metadata:
 sources:
   forecast:
     driver: opendap
-    description: 3D Tampa Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as nowcast.
+    description: 3D Tampa Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -31,40 +31,11 @@ sources:
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.regulargrid.n001.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/TBOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.tbofs.regulargrid.n002.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t00z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 48 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    driver: opendap
-    description: 3D Tampa Bay model in ROMS, interpolated to regular grid, from 1 day ago with 48 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/TBOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 48 hours after present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/wcofs.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/wcofs.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: West Coast model in ROMS from 30 days ago with 72 hour forecast. Same as nowcast.
+    description: West Coast model in ROMS from 30 days ago with 72 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -31,43 +31,11 @@ sources:
         default: today
     driver: opendap
     metadata:
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      ]
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 72 hours after present time'
-      output_period_(hr): 3
-      axis:
-        T: ocean_time
-        X: [xi_rho, xi_u, xi_v, xi_psi]
-        Y: [eta_rho, eta_u, eta_v, eta_psi]
-        Z: [z_rho, z_w]
-      standard_names:
-        eastward_sea_water_velocity: u
-        northward_sea_water_velocity: v
-        ocean_s_coordinate_g2: [s_rho, s_w]
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-        upward_sea_water_velocity: w
-
-  nowcast:
-    description: West Coast model in ROMS from 30 days ago with 72 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: null
-    driver: opendap
-    metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 3
@@ -101,8 +69,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-wcofs-files/2022/07/nos.wcofs.fields.n003.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-wcofs-files/2022/07/nos.wcofs.fields.n003.20220702.t03z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-wcofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-wcofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2021-03-22'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/catalogs/orig/wcofs_2ds.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/wcofs_2ds.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: West Coast model in ROMS from 30 days ago with 72 hour forecast. Same as nowcast.
+    description: West Coast model in ROMS from 30 days ago with 72 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -21,60 +21,21 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.2ds.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
+    driver: opendap
     parameters:
       tod:
         description: Pandas like Timestamp for today
         type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
         default: today
-    driver: opendap
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available from a month before present day.'
-      overall_end_datetime: 'Available through 72 hours after present time'
-      output_period_(hr): 1
-      axis:
-        T: ocean_time
-        X: [xi_rho, xi_u, xi_v, xi_psi]
-        Y: [eta_rho, eta_u, eta_v, eta_psi]
-      standard_names:
-        eastward_sea_water_velocity: u_sur
-        eastward_wind: Uwind
-        northward_sea_water_velocity: v_sur
-        northward_wind: Vwind
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp_sur
-        sea_water_practical_salinity: salt_sur
-        time: ocean_time
-
-  nowcast:
-    description: West Coast model in ROMS from 30 days ago with 72 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.2ds.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.2ds.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    driver: opendap
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available from a month before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 1
@@ -107,8 +68,10 @@ sources:
       engine: netcdf4
       urlpath: null
     metadata:
+      # Sample files with known dates
+      sample_locs: ["https://www.ncei.noaa.gov/thredds/dodsC/model-wcofs-files/2022/07/nos.wcofs.2ds.n001.20220701.t03z.nc",
+      "https://www.ncei.noaa.gov/thredds/dodsC/model-wcofs-files/2022/07/nos.wcofs.2ds.n001.20220702.t03z.nc"]
       catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-wcofs-files/catalog.xml'
-      # catloc: 'https://www.ncei.noaa.gov/thredds/catalog/model-wcofs-files/{date.year}/{str(date.month).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 2021-03-22'
       overall_end_datetime: 'Available through 4 days before present time'
       output_period_(hr): 1

--- a/model_catalogs/model_catalogs/catalogs/orig/wcofs_regulargrid.yaml
+++ b/model_catalogs/model_catalogs/catalogs/orig/wcofs_regulargrid.yaml
@@ -10,7 +10,7 @@ metadata:
 
 sources:
   forecast:
-    description: West Coast model in ROMS, interpolated to regular grid, from 1 day ago with 72 hour forecast. Same as nowcast.
+    description: West Coast model in ROMS, interpolated to regular grid, from 1 day ago with 72 hour forecast.
     args:
       chunks:
         ocean_time: 1
@@ -21,8 +21,8 @@ sources:
       coords: minimal
       engine: netcdf4
       urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.regulargrid.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.regulargrid.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
     parameters:
       tod:
@@ -31,48 +31,11 @@ sources:
         default: today
     driver: opendap
     metadata:
-      catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
-      overall_start_datetime: 'Available starting 1 day before present day.'
-      overall_end_datetime: 'Available through 72 hours after present time'
-      output_period_(hr): 3
-      axis:
-        T: ocean_time
-        X: nx
-        Y: ny
-        Z: Depth
-      standard_names:
-        eastward_sea_water_velocity: u_eastward
-        northward_sea_water_velocity: v_northward
-        sea_floor_depth: h
-        sea_surface_height_above_mean_sea_level: zeta
-        sea_water_temperature: temp
-        sea_water_practical_salinity: salt
-        time: ocean_time
-  nowcast:
-    description: West Coast model in ROMS, interpolated to regular grid, from 30 days ago with 72 hour forecast. Same as forecast.
-    args:
-      chunks:
-        ocean_time: 1
-      compat: override
-      combine: by_coords
-      parallel: True
-      data_vars: minimal
-      coords: minimal
-      engine: netcdf4
-      urlpath: [
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
-      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.fields.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      sample_locs: [
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.regulargrid.n003.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
+      "https://opendap.co-ops.nos.noaa.gov/thredds/dodsC/NOAA/WCOFS/MODELS/{{tod.year}}/{{tod.strftime('%m')}}/{{tod.strftime('%d')}}/nos.wcofs.regulargrid.n006.{{tod.year}}{{tod.strftime('%m')}}{{tod.strftime('%d')}}.t03z.nc",
       ]
-    parameters:
-      tod:
-        description: Pandas like Timestamp for today
-        type: datetime  # one of bool, str, int, float, list[str | int | float], datetime,
-        default: today
-    driver: opendap
-    metadata:
       catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/catalog.xml'
-      # catloc: 'https://opendap.co-ops.nos.noaa.gov/thredds/catalog/NOAA/WCOFS/MODELS/{date.year}/{str(date.month).zfill(2)}/{str(date.day).zfill(2)}/catalog.xml'
       overall_start_datetime: 'Available starting 1 day before present day.'
       overall_end_datetime: 'Available through 72 hours after present time'
       output_period_(hr): 3

--- a/model_catalogs/model_catalogs/examples.py
+++ b/model_catalogs/model_catalogs/examples.py
@@ -84,6 +84,7 @@ def parse_bbox(val: str) -> Tuple[float, float, float, float]:
 
 
 def fetch(fetch_config):
+    """Fetch output"""
     print("Setting up source catalog")
     with Timer("\tSource catalog generated in {:.1f} ms"):
         source_catalog = mc.setup_source_catalog()
@@ -132,6 +133,8 @@ def parse_config(
     default_start=None,
     default_end=None,
 ) -> FetchConfig:
+    """Parse config file"""
+
     if standard_names is None:
         standard_names = STANDARD_NAMES
     parser = ArgumentParser(description=main.__doc__)

--- a/model_catalogs/model_catalogs/model_catalogs.py
+++ b/model_catalogs/model_catalogs/model_catalogs.py
@@ -435,7 +435,7 @@ def find_availability(model, override=False, override_updated=False):
         )
         return new_user_cat
 
-    
+
 def transform_source(source_orig):
     """DOCSTRINGS"""
 
@@ -478,7 +478,7 @@ def transform_source(source_orig):
         sources,
         "User-catalog.",
         "User-made catalog.",
-        source_transform.metadata,  # this is where the most metadata is, but probably not important for cat
+        source_transform.metadata,  # this is where the most metadata is, but probably not important for cat  # noqa: E501
         [source._entry._driver for source in sources],
         cat_path=mc.CATALOG_PATH_TMP,
     )
@@ -545,15 +545,7 @@ def add_url_path(cat, timing=None, start_date=None, end_date=None):
     if not isinstance(end_date, pd.Timestamp):
         end_date = pd.Timestamp(end_date)
 
-    # # which source to use from catalog for desired date range
-    # if "RTOFS" in model:
-    #     if "GLOBAL" in model:
-    #         source_orig = cat[timing](yesterday=pd.Timestamp.today()-pd.Timedelta('1 day'))            
-    #     else:
-    #         # RTOFS needs to have yesterday's date input, then it is able to
-    #         # create the necessary file names to get the model output
-    #         source_orig = cat[timing](yesterday=pd.Timestamp.today()-pd.Timedelta('1 day'))
-
+    # which source to use from catalog for desired date range
     if timing is None:
         if start_date >= pd.Timestamp(
             cat["forecast"].metadata["start_datetime"]
@@ -575,15 +567,14 @@ def add_url_path(cat, timing=None, start_date=None, end_date=None):
 
     # RTOFS has special issues to form the paths for the model output available right now
     if "RTOFS-EAST" in model or "RTOFS-ALASKA" in model or "RTOFS-WEST" in model:
-        # if "GLOBAL" in model:
-        #     source_orig = cat[timing]         
-        # else:
         # RTOFS needs to have yesterday's date input, then it is able to
         # create the necessary file names to get the model output
-        source_orig = cat[timing](yesterday=pd.Timestamp.today()-pd.Timedelta('1 day'))
-    
+        source_orig = cat[timing](
+            yesterday=pd.Timestamp.today() - pd.Timedelta("1 day")
+        )
+
     elif "RTOFS-GLOBAL" in model or "RTOFS-GLOBAL_2D" in model:
-        source_orig = cat[timing]         
+        source_orig = cat[timing]
 
     # urlpath is None or a list of filler files if the filepaths need to be determined
     elif (
@@ -624,7 +615,9 @@ def add_url_path(cat, timing=None, start_date=None, end_date=None):
 
             ind = catrefs.index(cat_ref_to_match)
 
-            filelocs = mc.find_filelocs(catrefs[ind], catloc, filetype=cat.metadata["filetype"])
+            filelocs = mc.find_filelocs(
+                catrefs[ind], catloc, filetype=cat.metadata["filetype"]
+            )
             filelocs_urlpath.extend(
                 mc.agg_for_date(
                     date,
@@ -662,8 +655,12 @@ def add_url_path(cat, timing=None, start_date=None, end_date=None):
     # store info in source_orig
     # source_orig.metadata["model"] = model
     source_orig.metadata["timing"] = timing
-    source_orig.metadata["start_date"] = start_date.isoformat() if start_date is not None else None,
-    source_orig.metadata["end_date"] = end_date.isoformat() if end_date is not None else None,
+    source_orig.metadata["start_date"] = (
+        start_date.isoformat() if start_date is not None else None,
+    )
+    source_orig.metadata["end_date"] = (
+        end_date.isoformat() if end_date is not None else None,
+    )
     # Add original overall model catalog metadata to this next version
     source_orig.metadata.update(cat.metadata)
 

--- a/model_catalogs/model_catalogs/process.py
+++ b/model_catalogs/model_catalogs/process.py
@@ -47,7 +47,8 @@ def add_attributes(ds, axis, standard_names):
         if not isinstance(var_names, list):
             var_names = [var_names]
         for var_name in var_names:
-            ds[var_name].attrs["standard_name"] = stan_name
+            if var_name in ds.data_vars:
+                ds[var_name].attrs["standard_name"] = stan_name
 
     # # Run code to find vertical coordinates
     # try:
@@ -93,5 +94,10 @@ def add_attributes(ds, axis, standard_names):
     # decode times if times are floats
     if ds.cf["T"].dtype == "float64":
         ds = xr.decode_cf(ds, decode_times=True)
+
+    # This is an internal attribute used by netCDF which xarray doesn't know or care about, but can
+    # be returned from THREDDS.
+    if "_NCProperties" in ds.attrs:
+        del ds.attrs["_NCProperties"]
 
     return ds

--- a/model_catalogs/model_catalogs/tests/test_catalogs.py
+++ b/model_catalogs/model_catalogs/tests/test_catalogs.py
@@ -52,13 +52,13 @@ def test_setup_source_catalog():
     assert sorted(list(source_cat["CBOFS"])) == ["forecast", "hindcast", "nowcast"]
 
 
-def test_find_availability():
-    """Make sure one test case works for this."""
+# def test_find_availability():
+#     """Make sure one test case works for this."""
 
-    cat = mc.find_availability(model="DBOFS", override_updated=True)
+#     cat = mc.find_availability(model="DBOFS", override_updated=True)
 
-    assert "start_datetime" in cat["forecast"].metadata
-    assert "time_last_checked" in cat["forecast"].metadata
+#     assert "start_datetime" in cat["forecast"].metadata
+#     assert "time_last_checked" in cat["forecast"].metadata
 
 
 @pytest.mark.slow

--- a/model_catalogs/model_catalogs/tests/test_files/cbofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/cbofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de00781d421eed44833ea0beec032844d44c2f8577082d6739821c04d32bb361
+size 84697

--- a/model_catalogs/model_catalogs/tests/test_files/cbofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/cbofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b39ee0ae71acfdfa2030f96c0ebe1b789721bf34b3e5019a8cb62a5ec0f4b942
+size 84648

--- a/model_catalogs/model_catalogs/tests/test_files/cbofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/cbofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8afea2d57cb7c46aedf5b8c3a6bcea1794b6b0d2c6f12fdccd5033f61ff7235e
+size 41488

--- a/model_catalogs/model_catalogs/tests/test_files/ciofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/ciofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71f9fd48bf1c16c67eeda10bfa3df80a4b16b185a49364b28a913148cbdea124
+size 114961

--- a/model_catalogs/model_catalogs/tests/test_files/ciofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/ciofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7357177fc52cdea38738d79605ff9ad2e860fea5b4c41b7305bb1ec368237a44
+size 104441

--- a/model_catalogs/model_catalogs/tests/test_files/ciofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/ciofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9656aaf21e8820100ce0df22b8a8a8946b5f7eb1e369a1b70febd7a0a9f6abfb
+size 104225

--- a/model_catalogs/model_catalogs/tests/test_files/ciofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/ciofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ffc3e02e25a0782b89517bc348a7812ac62dd39fc0a4dfcee72fb85066f53a79
+size 40311

--- a/model_catalogs/model_catalogs/tests/test_files/creofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/creofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cbc0dc9aef2ba229118d0213cbaa6c04343868317ce0d7b833bedfb1bff74542
+size 37259

--- a/model_catalogs/model_catalogs/tests/test_files/dbofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/dbofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:785192fb81f05640d2425eaad8006ed22cf4b9e9cfaa63c2cdc9bccd2c06586a
+size 102491

--- a/model_catalogs/model_catalogs/tests/test_files/dbofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/dbofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5edecf0b08b53945aa077757becfdde04ec8b001b8899b846ca9b1ad9e2b749d
+size 84527

--- a/model_catalogs/model_catalogs/tests/test_files/dbofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/dbofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8c9762ac0c50eab8ba53cc2743a752708467de88a048e4d4637ed2b9078f18e2
+size 84478

--- a/model_catalogs/model_catalogs/tests/test_files/dbofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/dbofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:405ecd945a7384272c56205f9613600b74a5ec77dc6a37ab6bb33f323424a206
+size 41488

--- a/model_catalogs/model_catalogs/tests/test_files/gfs-1_2deg_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gfs-1_2deg_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cd6d43d9d739e2a44df9ce4844c3bd70a47c18b5e59abaaf876bc70fef428eb6
+size 49910

--- a/model_catalogs/model_catalogs/tests/test_files/gfs-1_4deg_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gfs-1_4deg_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d69eb98f28f26f9a699499f410c611239fb0c1c7964cd5da1cab31a1ff68ea2
+size 49910

--- a/model_catalogs/model_catalogs/tests/test_files/gfs-1deg_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gfs-1deg_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:571b5610fd83b4b08baff331129c1bcd9584f3708637e1f7c33fac81b9e5a9af
+size 49910

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_2ds_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_2ds_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a6194100ace5a895332c55652fd0eac8482a3b68de8ed995fe919fff04f11c6
+size 92846

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_2ds_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_2ds_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3c0b9a2e5eccff95ec27af0f6191bed1cb941c46699ee0821ad958952271d0f
+size 92895

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f52f81c87717b5b3b2504d2479a8a70a028369a758ee95302a18a910fca65a19
+size 115648

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63fe5860199ce498676e4fd0d5f96d3b10ec49b1b64744861db9450ca7799347
+size 104231

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:687df686dcd9f53317f48bb9426ab92c82f26709237d3b04ed00b9f34c1ab239
+size 104172

--- a/model_catalogs/model_catalogs/tests/test_files/gomofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/gomofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fb10a57f29b93dea5610248f245b271147e257060ddba7c3c4baf11ab9f20814
+size 41492

--- a/model_catalogs/model_catalogs/tests/test_files/hycom_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/hycom_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19da022b977e796582f908b5cf0b8049a1b19f847469f205d68b7f23bcfbcab6
+size 41933

--- a/model_catalogs/model_catalogs/tests/test_files/leofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/leofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f20da56a96f92803190ccef36321797fb712c25a08a1b62a9ebdb6d05c90dfb9
+size 38456

--- a/model_catalogs/model_catalogs/tests/test_files/lmhofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/lmhofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b1f5208c5bf873457cc7ce5114ea90f40d9811a9e562476b04988ead6d9bd76
+size 38254

--- a/model_catalogs/model_catalogs/tests/test_files/loofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/loofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7e4022d7f815a037cf1fe55005171792f0320b471c182fd279b4a94fa7566bf
+size 37232

--- a/model_catalogs/model_catalogs/tests/test_files/loofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/loofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8758f7c5c007c6f8c4e6c6858b9d5fa78d991de142b476fe8e5e40c27123743c
+size 35332

--- a/model_catalogs/model_catalogs/tests/test_files/loofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/loofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:926eee5cf5057c942b7431568c9064d43cb807e02d86c68d37aef9e5243c9970
+size 35732

--- a/model_catalogs/model_catalogs/tests/test_files/lsofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/lsofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd28885eb695c0bb5f0870910fad00a5bda8fb651b738cbbcdbab7efcfe47be6
+size 37710

--- a/model_catalogs/model_catalogs/tests/test_files/lsofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/lsofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45e55fb09354391ab5516c9b959d430497d5f3d03d9578ada55c3e911cef4121
+size 35332

--- a/model_catalogs/model_catalogs/tests/test_files/lsofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/lsofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0222c6bfd263843045b1f97f878a3ae0f1d7055bd8c75560a4636e09f44f71dc
+size 35332

--- a/model_catalogs/model_catalogs/tests/test_files/ngofs2_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/ngofs2_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:430fae454ecea6c88a420b4dbd47571ef78ba412f2a7e8405874814db4e3af0d
+size 39279

--- a/model_catalogs/model_catalogs/tests/test_files/nyofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/nyofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a7b71f0d332309e0bd6afeeffcbc4ade4efc9955d734a474713da6bd2cbd4d8
+size 42034

--- a/model_catalogs/model_catalogs/tests/test_files/nyofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/nyofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fae50441027cef4c72dfa13fc26f43eb1130f5359f9e862199eae43446f3933d
+size 40059

--- a/model_catalogs/model_catalogs/tests/test_files/nyofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/nyofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e050b65e13f220a3a47a851f2c7d02574656251b3e419ea78c11bfa0ab2484d
+size 40059

--- a/model_catalogs/model_catalogs/tests/test_files/sfbofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/sfbofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c81d9967521d311d9d968eb0c323903219d5b8fb9fd49cb4ffb6ba07f6f9a1db
+size 38456

--- a/model_catalogs/model_catalogs/tests/test_files/tbofs_hindcast-forecast-aggregation.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/tbofs_hindcast-forecast-aggregation.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38ece42d35c3f5f161fd75f73aa907e76fc078954a39040a66b33681f4f3e651
+size 113062

--- a/model_catalogs/model_catalogs/tests/test_files/tbofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/tbofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e7e275d4e36f536a469442ab7454e1547197a23fd7b9af52e97b229013dd646d
+size 104515

--- a/model_catalogs/model_catalogs/tests/test_files/tbofs_nowcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/tbofs_nowcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e77f2e9aea9153151e89e0657983ce7159dae8fc59684b8072464563228231af
+size 104466

--- a/model_catalogs/model_catalogs/tests/test_files/tbofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/tbofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30cbd80d8504b8b2622f5935f8e773b1e0c69a06174a514c9493a7391703824b
+size 41488

--- a/model_catalogs/model_catalogs/tests/test_files/wcofs_2ds_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/wcofs_2ds_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7444ce64155bd9bdba475f6940c2695c08d193ac4aa314700d0e5a0e38fd881b
+size 77380

--- a/model_catalogs/model_catalogs/tests/test_files/wcofs_2ds_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/wcofs_2ds_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18b373621d30b983025c2614834ac25e26b09cb2e27217780ec3562747d4b01f
+size 77380

--- a/model_catalogs/model_catalogs/tests/test_files/wcofs_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/wcofs_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97cdd0afadf6b25bad3542d2d6c4b4677e44a3dfce7444b8dd18b4ca544e9e67
+size 84425

--- a/model_catalogs/model_catalogs/tests/test_files/wcofs_hindcast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/wcofs_hindcast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b408fe47ec77a423e3e80da3b6ae83852099f6825a3920618035dc3e0a84e49
+size 84425

--- a/model_catalogs/model_catalogs/tests/test_files/wcofs_regulargrid_forecast.nc
+++ b/model_catalogs/model_catalogs/tests/test_files/wcofs_regulargrid_forecast.nc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:24f1b358c9e5fc99137e3ffe22ebb2b7f34c56cc25c3b1072e9b3c88b7499308
+size 41496

--- a/model_catalogs/model_catalogs/tests/test_process.py
+++ b/model_catalogs/model_catalogs/tests/test_process.py
@@ -4,12 +4,15 @@ Test process functions.
 
 import model_catalogs as mc
 
+
 def astype(value, type_):
+    """Return string or list as list"""
     if not isinstance(value, type_):
         if type_ == list and type(value) == str:
             return [value]
         return type_(value)
     return value
+
 
 # @pytest.mark.slow
 def test_process():
@@ -22,32 +25,51 @@ def test_process():
             print(model, timing)
             cat = source_cat[model]
             source_orig = cat[timing]
-            
+
             # use local version of model output
-            source_orig._captured_init_kwargs['urlpath'] = [f'model_catalogs/notebooks/test_files/{model}_{timing}.nc']
-            
+            source_orig._captured_init_kwargs["urlpath"] = [
+                f"model_catalogs/notebooks/test_files/{model}_{timing}.nc"
+            ]
+
             # REMOVE THIS ONCE THIS FUNCTIONALITY IS BUILT IN
             cat_transform = mc.transform_source(source_orig)
             source_transform = cat_transform[model]
-            
+
             # ONCE I HAVE A FILE FOR ALL MODELS, remove try/except here
             # Replace dynamic urlpath with local static version
             try:
                 ds = source_transform.to_dask()
-            except:
+            except FileNotFoundError:
                 continue
-            
+
             # check axis attributes have been assigned
-            checks = [ds[var_name].attrs['axis'] == axis for axis, var_names in source_transform.metadata['axis'].items() for var_name in astype(var_names, list) if var_name in ds.dims]
+            checks = [
+                ds[var_name].attrs["axis"] == axis
+                for axis, var_names in source_transform.metadata["axis"].items()
+                for var_name in astype(var_names, list)
+                if var_name in ds.dims
+            ]
             assert all(checks)
-            
+
             # check standard_names attributes have been assigned
-            checks = [ds[var_name].attrs['standard_name'] == st_name for st_name, var_names in source_transform.metadata['standard_names'].items() for var_name in astype(var_names, list) if var_name in ds.data_vars]
+            checks = [
+                ds[var_name].attrs["standard_name"] == st_name
+                for st_name, var_names in source_transform.metadata[
+                    "standard_names"
+                ].items()
+                for var_name in astype(var_names, list)
+                if var_name in ds.data_vars
+            ]
             assert all(checks)
-            
+
             # check cf-xarray
             # AXIS X and Y won't be defined for unstructured model
-            assert sorted(list(ds.cf.axes.keys())) == ['T', 'X', 'Y', 'Z']
-            assert sorted(list(ds.cf.coordinates.keys())) == ['latitude', 'longitude', 'time', 'vertical']
+            assert sorted(list(ds.cf.axes.keys())) == ["T", "X", "Y", "Z"]
+            assert sorted(list(ds.cf.coordinates.keys())) == [
+                "latitude",
+                "longitude",
+                "time",
+                "vertical",
+            ]
 
             ds.close()

--- a/model_catalogs/model_catalogs/tests/test_process.py
+++ b/model_catalogs/model_catalogs/tests/test_process.py
@@ -1,0 +1,55 @@
+"""
+Test process functions.
+"""
+
+import model_catalogs as mc
+
+# what controls urlpath?
+# NOT THIS:  source_transform._captured_init_kwargs['metadata']['urlpath']
+# THIS DOES NOT SINCE NOT ALREADYD LOADED!!!!! source_transform._source.urlpath
+
+def astype(value, type_):
+    if not isinstance(value, type_):
+        if type_ == list and type(value) == str:
+            return [value]
+        return type_(value)
+    return value
+
+# @pytest.mark.slow
+def test_process():
+    """Test all models for transform."""
+    # CHECK:
+    # cf-xarray identification
+
+    source_cat = mc.setup_source_catalog()
+
+    for model in ['CBOFS']:# list(source_cat):
+        for timing in ['hindcast']:# list(source_cat[model]):
+            print(model, timing)
+            cat = source_cat[model]
+            source_orig = cat[timing]
+            
+            # use local version of model output
+            source_orig._captured_init_kwargs['urlpath'] = [f'model_catalogs/notebooks/test_files/{model}_{timing}.nc']
+            
+            cat_transform = mc.transform_source(source_orig)
+            source_transform = cat_transform[model]
+            # Replace dynamic urlpath with local static version
+            # import pdb; pdb.set_trace()
+            # source_transform._source.urlpath = f'model_catalogs/notebooks/test_files/{model}_{timing}.nc'
+            ds = source_transform.to_dask()
+            
+            # check axis attributes have been assigned
+            checks = [ds[var_name].attrs['axis'] == axis for axis, var_names in source_transform.metadata['axis'].items() for var_name in astype(var_names, list) if var_name in ds.dims]
+            assert all(checks)
+            
+            # check standard_names attributes have been assigned
+            checks = [ds[var_name].attrs['standard_name'] == st_name for st_name, var_names in source_transform.metadata['standard_names'].items() for var_name in astype(var_names, list) if var_name in ds.data_vars]
+            assert all(checks)
+            
+            # check cf-xarray
+            # AXIS X and Y won't be defined for unstructured model
+            assert sorted(list(ds.cf.axes.keys())) == ['T', 'X', 'Y', 'Z']
+            assert sorted(list(ds.cf.coordinates.keys())) == ['latitude', 'longitude', 'time', 'vertical']
+
+            ds.close()

--- a/model_catalogs/model_catalogs/tests/test_process.py
+++ b/model_catalogs/model_catalogs/tests/test_process.py
@@ -4,10 +4,6 @@ Test process functions.
 
 import model_catalogs as mc
 
-# what controls urlpath?
-# NOT THIS:  source_transform._captured_init_kwargs['metadata']['urlpath']
-# THIS DOES NOT SINCE NOT ALREADYD LOADED!!!!! source_transform._source.urlpath
-
 def astype(value, type_):
     if not isinstance(value, type_):
         if type_ == list and type(value) == str:
@@ -18,13 +14,11 @@ def astype(value, type_):
 # @pytest.mark.slow
 def test_process():
     """Test all models for transform."""
-    # CHECK:
-    # cf-xarray identification
 
     source_cat = mc.setup_source_catalog()
 
-    for model in ['CBOFS']:# list(source_cat):
-        for timing in ['hindcast']:# list(source_cat[model]):
+    for model in list(source_cat):
+        for timing in list(source_cat[model]):
             print(model, timing)
             cat = source_cat[model]
             source_orig = cat[timing]
@@ -32,12 +26,16 @@ def test_process():
             # use local version of model output
             source_orig._captured_init_kwargs['urlpath'] = [f'model_catalogs/notebooks/test_files/{model}_{timing}.nc']
             
+            # REMOVE THIS ONCE THIS FUNCTIONALITY IS BUILT IN
             cat_transform = mc.transform_source(source_orig)
             source_transform = cat_transform[model]
+            
+            # ONCE I HAVE A FILE FOR ALL MODELS, remove try/except here
             # Replace dynamic urlpath with local static version
-            # import pdb; pdb.set_trace()
-            # source_transform._source.urlpath = f'model_catalogs/notebooks/test_files/{model}_{timing}.nc'
-            ds = source_transform.to_dask()
+            try:
+                ds = source_transform.to_dask()
+            except:
+                continue
             
             # check axis attributes have been assigned
             checks = [ds[var_name].attrs['axis'] == axis for axis, var_names in source_transform.metadata['axis'].items() for var_name in astype(var_names, list) if var_name in ds.dims]


### PR DESCRIPTION
This is a work in progress, but everything that has happened so far works, it just needs to be added to still.

There are now sample files for many of the models which can be used for local testing, and they are currently tested in `test_process.py`. Some models still need to be included: all forecast aggregations because they are currently not working, all unstructured models because I need to use code that Luke is merging sometime soon to subset the models, and all RTOFS model output because I can't seem to access the output with my setup currently.

Most of the catalog files have been modified with some rearranging and adding sample file locations which are handy to have available (`sample_locs`). 

I also separated out the function that transforms a source (`transform_source`) so that I can use it more widely.

I plan to come back to these changes next week and continue working on them, but use these changes in some other work in the meantime.