### PR TITLE
Unpins intake-xarray version

### DIFF
--- a/model_catalogs/ci/environment-py3.8.yml
+++ b/model_catalogs/ci/environment-py3.8.yml
@@ -24,7 +24,7 @@ dependencies:
   - pytest
   - pip:
       # intake-xarray version on 2022-07-28 which has fixes for using non-standard engine
-    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
+    - git+https://github.com/intake/intake-xarray.git
     - git+https://github.com/intake/intake.git
     - datetimerange
     - codecov

--- a/model_catalogs/ci/environment-py3.8.yml
+++ b/model_catalogs/ci/environment-py3.8.yml
@@ -23,7 +23,8 @@ dependencies:
   ##############
   - pytest
   - pip:
-    - git+https://github.com/intake/intake-xarray.git #@open_mfdataset
+      # intake-xarray version on 2022-07-28 which has fixes for using non-standard engine
+    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
     - git+https://github.com/intake/intake.git
     - datetimerange
     - codecov

--- a/model_catalogs/ci/environment-py3.9.yml
+++ b/model_catalogs/ci/environment-py3.9.yml
@@ -24,7 +24,7 @@ dependencies:
   - pytest
   - pip:
       # intake-xarray version on 2022-07-28 which has fixes for using non-standard engine
-    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
+    - git+https://github.com/intake/intake-xarray.git
     - git+https://github.com/intake/intake.git
     - datetimerange
     - codecov

--- a/model_catalogs/ci/environment-py3.9.yml
+++ b/model_catalogs/ci/environment-py3.9.yml
@@ -23,7 +23,8 @@ dependencies:
   ##############
   - pytest
   - pip:
-    - git+https://github.com/intake/intake-xarray.git #@open_mfdataset
+      # intake-xarray version on 2022-07-28 which has fixes for using non-standard engine
+    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
     - git+https://github.com/intake/intake.git
     - datetimerange
     - codecov

--- a/model_catalogs/environment.yml
+++ b/model_catalogs/environment.yml
@@ -29,7 +29,7 @@ dependencies:
     # - git+https://github.com/axiom-data-science/extract_model.git
     # - git+https://github.com/xarray-contrib/cf-xarray.git
     #- git+https://github.com/intake/intake-xarray.git #@open_mfdataset
-    - git+https://github.com/intake/intake-xarray.git@b78950df8d1ca1250909ee2aaa0bc28cf1f0b59e
+    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
     #- git+https://github.com/intake/intake.git
     - git+https://github.com/intake/intake.git@d28391c54c875a47bf34f640e46c5f68109ba8b5
     #- git+https://github.com/axiom-data-science/extract_model.git

--- a/model_catalogs/environment.yml
+++ b/model_catalogs/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - cf_xarray
   - dask
   - flake8
-  # - extract_model>=0.8.0
+  - extract_model
   - h5netcdf
   # - intake
   # - intake-xarray
@@ -27,9 +27,7 @@ dependencies:
   - xarray
   - pip:  # install from github to get recent PRs I contributed
     # - git+https://github.com/axiom-data-science/extract_model.git
-    # - git+https://github.com/xarray-contrib/cf-xarray.git
-    #- git+https://github.com/intake/intake-xarray.git #@open_mfdataset
-    - git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
+    - git+https://github.com/intake/intake-xarray.git
     #- git+https://github.com/intake/intake.git
     - git+https://github.com/intake/intake.git@d28391c54c875a47bf34f640e46c5f68109ba8b5
     #- git+https://github.com/axiom-data-science/extract_model.git

--- a/model_catalogs/pip_requirements.txt
+++ b/model_catalogs/pip_requirements.txt
@@ -1,4 +1,4 @@
 datetimerange
-git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
+git+https://github.com/intake/intake-xarray.git
 git+https://github.com/intake/intake.git
 siphon  # can get from conda-forge but isn't recognized

--- a/model_catalogs/pip_requirements.txt
+++ b/model_catalogs/pip_requirements.txt
@@ -1,4 +1,4 @@
 datetimerange
-git+https://github.com/intake/intake-xarray.git
+git+https://github.com/intake/intake-xarray.git@f8368225d6957e5fb0a4b2f24f0b0be28b42a5ea
 git+https://github.com/intake/intake.git
 siphon  # can get from conda-forge but isn't recognized


### PR DESCRIPTION
This commit unpins the intake-xarray version which should now include a fix for loading FVCOM data into xarray.