### PR TITLE
add some doctrings to api.py

### DIFF
--- a/libgoods/libgoods/api.py
+++ b/libgoods/libgoods/api.py
@@ -11,9 +11,11 @@ import warnings
 from shapely.geometry import Polygon, MultiPoint
 # import shapely.wkt as wkt
 # from . import utilities
-# from . import FileTooBigError
+from . import FileTooBigError
 from .model import ENVIRONMENTAL_PARAMETERS, Metadata
+
 import numpy as np
+
 
 try:
     import model_catalogs as mc
@@ -22,6 +24,10 @@ try:
 except ImportError:
     warnings.warn("model_catalogs not found: libgoods API will not work")
 
+
+##################
+# utility functions -- implementation, not API
+##################
 
 def _filter_by_env_params(mdl_meta, ev_p):
     '''
@@ -79,11 +85,27 @@ def filter_models(models_metadatas, map_bounds=None, name_list=None, env_params=
 
     return retlist
 
+###########
+# API functions -- these are what WebGNOME will call
+###########
+
 def list_models(name_list=None, map_bounds=None, env_params=None, as_pyson=False):
     """
     Return metadata for all available models
 
     This is the static information about the models
+
+    :param name_list=None: Optional list of particular models names. If None
+                           all available models will be returned
+    :param map_bounds: Bounds within which the models can overlap, if None, the whole world
+
+    :param env_params=None: Only provide models that have the given parameters
+
+    :param as_pyson=False: If True, result is JSON-compatible dict.
+                           If false, Metadata objects.
+
+    :returns: list of metadata for models that satisfy the criteria
+
     """
     retval = filter_models(all_metas.values(),
         name_list=name_list,
@@ -93,14 +115,21 @@ def list_models(name_list=None, map_bounds=None, env_params=None, as_pyson=False
         retval = [m.as_pyson() for m in retval]
     return retval
 
+
 def get_model_info(model_name):
     """
     Return metadata about a particular model
+
+    :param model_name: the name (unique ID) of the model.
+
+    :returns: libgoods.models.Metadata object with metadata of the model.
+
     """
     if model_name not in env_models:
         raise KeyError(f"{model_name} is not a valid model name")
     else:
         return Metadata(model=env_models[model_name])
+
 
 def get_model_subset_info(
     model_id,
@@ -137,10 +166,32 @@ def get_model_data(
     max_filesize=None,
     target_dir=None,
 ):
+    """
+    Get the actual model data as a netcdf file.
+
+    :param model_id: ID (name) of the model
+    :param bounds: bounds to subset to -- if the implementation doesn't
+                   support polygons, the bonding box of the bounds will be used.
+    :param time_interval: time span to subset to -- pair of datetime objects
+
+    :param environmental_parameters: which environmental parameters to extract
+
+    :param cross_dateline=False: whether the subset crosses the dateline
+
+    :param max_filesize = None: maximum filesize to generate -- if the file will
+                          be larger than this, raise a FileTooBigError
+
+    :param target_dir: directory to write the file too -- if None, it will be put
+                       in a temp dir or local dir.
+
+
+    :returns: Path object for the file
+    """
 
     if target_dir is not None:
         target_dir = Path(target_dir)
 
+    # NOTE: this implementation may not be appropriate
     source = all_models[model_id]
 
     filepath = source.get_data(


### PR DESCRIPTION
I added some documentation to api.py.

I didn't push directly to main, as I haven't had a chance to test -- all I did was comments and docstrings, so nothing should break, but you never know

@jay-hennen: I lost track of what we're still using, and what's leftover kruft -- could you take a look and correct and/or remove stuff. And merge it when you've done that (and tested)

@lukecampbell: take a look at api.py, hopefully the added docstrings will make things a bit more clear.

Note that we have a MetaData class in `libgoods.models` that we are using. The rest of what's in models is my original idea for a OO API to the models -- we'll probably dump all that.

