### PR TITLE
Rotates longitude to be [-180, 180]

### DIFF
--- a/libgoods/cli.py
+++ b/libgoods/cli.py
@@ -17,6 +17,7 @@ from libgoods.model_fetch import (
     get_times,
     FetchConfig,
     DEFAULT_STANDARD_NAMES,
+    get_bounds,
 )
 
 # These are just arbitrary boxes selected within the model's domain that demonstrates and offers a
@@ -26,19 +27,19 @@ EXAMPLE_BBOXES = {
     "CIOFS": (-154.5, 58.0, -151.0, 60.0),
     "CREOFS": (-123.9, 46.1, -123.6, 46.3),
     "DBOFS": (-75.5, 38.5, -74.5, 39.25),
-    "GFS-1DEG": (275.0, 25.0, 300.0, 48.0),
-    "HYCOM": (-79.10 + 360, 31.84, -68.159 + 360, 42.29),
-    "LEOFS": (276.4, 41.5, 277.4, 42.1),
-    "LMHOFS": (272, 41.57, 274, 44),
+    "GFS-1DEG": (-85.0, 25.0, -60.0, 48.0),
+    "HYCOM": (-79.10, 31.84, -68.159, 42.29),
+    "LEOFS": (-83.6, 41.5, -82.6, 42.1),
+    "LMHOFS": (-88, 41.57, -86, 44),
     "LOOFS": (-78.6, 43.4, -77.1, 43.7),
     "LSOFS": (-89.4, 47.0, -86.4, 47.75),
-    "NGOFS2": (268.5, 29.25, 269, 29.75),
-    "NGOFS2_2DS": (268.5, 29.25, 269, 29.75),
+    "NGOFS2": (-91.5, 29.25, -91, 29.75),
+    "NGOFS2-2DS": (-91.5, 29.25, -91, 29.75),
     "NYOFS": (-74.1, 40.49, -73.95, 40.61),
-    "SFBOFS": (237.45, 37.75, 237.6, 37.9),
+    "SFBOFS": (-122.55, 37.75, -122.4, 37.9),
     "TBOFS": (-82.9, 27.3, -82.6, 27.7),
     "WCOFS": (-122.0, 25.0, -115.0, 35.0),
-    "WCOFS_2DS": (-122.0, 25.0, -115.0, 35.0),
+    "WCOFS-2DS": (-122.0, 25.0, -115.0, 35.0),
 }
 
 
@@ -142,6 +143,19 @@ def _show_status(main_cat, model_name):
             start = ""
             end = ""
         print(f"{model_name:<20} {timing:<32} {str(status):<6} {str(start):<20} {end}")
+
+
+def _rotate_bbox(model_name, bbox) -> Tuple[float, float, float, float]:
+    """Performs checks on the bounding box relative to the model's bounds."""
+    bounds = get_bounds(model_name)
+    if bbox[2] < bounds[0]:
+        new_bbox = list(bbox)
+        if new_bbox[0] < 0:
+            new_bbox[0] += 360
+        if new_bbox[2] < 0:
+            new_bbox[2] += 360
+        return tuple(new_bbox)
+    return bbox
 
 
 def parse_config() -> FetchConfig:
@@ -296,6 +310,7 @@ def parse_config() -> FetchConfig:
             raise FileExistsError(f"{output_pth} already exists")
 
     bbox = parse_bbox(args.model_name, args.bbox)
+    bbox = _rotate_bbox(args.model_name, bbox)
 
     return FetchConfig(
         model_name=args.model_name,

--- a/libgoods/model_fetch.py
+++ b/libgoods/model_fetch.py
@@ -2,12 +2,11 @@
 # -*- coding: utf-8 -*-
 """A module containing code for fetching content from models."""
 import time
-import numpy as np
 from typing import List, Tuple, Mapping, Optional
 from pathlib import Path
-from datetime import datetime
 from dataclasses import field, dataclass
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 import requests
@@ -105,7 +104,7 @@ def get_times(model_name: str) -> Mapping[str, pd.Timestamp]:
 
 def get_source_online_status(model_name: str) -> Mapping[str, bool]:
     """Return a mapping of source to a boolean indicating if the source is available."""
-    yesterday = pd.Timestamp.today() - pd.Timedelta('1 day')
+    yesterday = pd.Timestamp.today() - pd.Timedelta("1 day")
     main_cat = mc.setup()
     statuses = {}
     for timing in main_cat[model_name]:
@@ -141,18 +140,22 @@ def is_coordinate_variable(ds: xr.Dataset, varname) -> bool:
 
 def rotate_longitude(ds: xr.Dataset):
     new_vars = {}
-    for varname in ds.filter_by_attrs(standard_name='longitude').variables:
-        if 'standard_name' not in ds[varname].attrs:
+    for varname in ds.filter_by_attrs(standard_name="longitude").variables:
+        if "standard_name" not in ds[varname].attrs:
             continue
-        if ds[varname].attrs['standard_name'] != 'longitude':
+        if ds[varname].attrs["standard_name"] != "longitude":
             continue
         lon_data = ds[varname][:].to_numpy()
         rotated_data = np.copy(lon_data)
         rotated_data[rotated_data > 180] -= 360
         if is_coordinate_variable(ds, varname) and not is_monotonic(rotated_data):
-            print("Longitude can not be rotated because the rotated data are not monotonic.")
+            print(
+                "Longitude can not be rotated because the rotated data are not monotonic."
+            )
         else:
-            xvar = xr.DataArray(rotated_data, dims=ds[varname].dims, attrs=ds[varname].attrs)
+            xvar = xr.DataArray(
+                rotated_data, dims=ds[varname].dims, attrs=ds[varname].attrs
+            )
             new_vars[varname] = xvar
     if len(new_vars) > 0:
         ds = ds.assign(new_vars)
@@ -172,7 +175,7 @@ def _check_axis(ds: xr.Dataset, axis: str) -> bool:
 
 def has_horizontal_data(ds: xr.Dataset) -> bool:
     """Return true if the horizontal size of the dataset is 0."""
-    horizontal_axes = ['X', 'Y']
+    horizontal_axes = ["X", "Y"]
     for axis in horizontal_axes:
         if _check_axis(ds, axis):
             return True
@@ -222,7 +225,7 @@ def fetch(fetch_config: FetchConfig):
             ds_ss = rotate_longitude(ds_ss)
 
         if not has_horizontal_data(ds_ss):
-            raise ValueError('Subsetting produced no valid data to write to disk.')
+            raise ValueError("Subsetting produced no valid data to write to disk.")
     # print("Loading dataset into memory.")
     # with Timer("\tLoaded into memory in {}"):
     #    #ds_ss = ds_ss.load(scheduler="processes")


### PR DESCRIPTION
This commit addresses 2 concerns:

- bounding box arguments passed to the CLI will be programmatically fixed to fit the model domain for longitude values. If you pass `(-180,  -10, -40, 20)` to a global model that uses [0, 360] it will be  transformed internally to `(180, -10, 320, 20)`.

- output files written to disk that have longitude values [0, 360] will  be written as [-180, 180] if and only if the coordinate values remain  monotonically increasing/decreasing.